### PR TITLE
Siddhi Version Bump. Added Auto deploy gh-pages plugin

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -89,6 +89,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>documentation-deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wso2.siddhi</groupId>
+                        <artifactId>siddhi-doc-gen</artifactId>
+                        <version>${siddhi.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>deploy-mkdocs-github-pages</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <build>
         <plugins>
             <plugin>
@@ -156,6 +178,18 @@
                             <dataFile>${basedir}/target/coverage-reports/jacoco.exec</dataFile>
                             <outputDirectory>${basedir}/target/coverage-reports/</outputDirectory>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.wso2.siddhi</groupId>
+                <artifactId>siddhi-doc-gen</artifactId>
+                <version>${siddhi.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-md-docs</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -309,10 +309,10 @@
         </dependencies>
     </dependencyManagement>
     <properties>
-        <siddhi.mapper.json.version>4.0.4</siddhi.mapper.json.version>
-        <siddhi.mapper.text.version>1.0.4</siddhi.mapper.text.version>
-        <siddhi.mapper.xml.version>4.0.0</siddhi.mapper.xml.version>
-        <siddhi.version>4.0.0-M78</siddhi.version>
+        <siddhi.mapper.json.version>4.0.5</siddhi.mapper.json.version>
+        <siddhi.mapper.text.version>1.0.5</siddhi.mapper.text.version>
+        <siddhi.mapper.xml.version>4.0.2</siddhi.mapper.xml.version>
+        <siddhi.version>4.0.0-M107</siddhi.version>
         <pax.exam.spi.version>4.10.0</pax.exam.spi.version>
         <commons.collections.version>3.1</commons.collections.version>
         <org.eclipse.osgi.services.version>3.5.100.v20160504-1419</org.eclipse.osgi.services.version>
@@ -466,7 +466,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
-                        <preparationGoals>clean install</preparationGoals>
+                        <preparationGoals>clean install -Pdocumentation-deploy</preparationGoals>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>
                 </plugin>
@@ -513,18 +513,6 @@
                         <forkMode>once</forkMode>
                         <argLine>-ea -Xmx512m</argLine>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.wso2.siddhi</groupId>
-                    <artifactId>siddhi-doc-gen</artifactId>
-                    <version>${siddhi.version}</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>generate-md-docs</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Purpose
> Make GitHub io site auto deploy on gh-pages.

## Approach
> Update the siddhi version to M107.
> Update Mapper versions to releases that use siddhi version M106 or higher
Add relevant plugins and profile to pom.xml files to make site auto deploy on gh-pages in release build.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes