### PR TITLE
This edits the readme file of the siddhi-io-http repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 siddhi-io-http
 ======================================
 
-The **siddhi-io-http extension** is an extension to <a target="_blank" href="https://wso2.github.io/siddhi">Siddhi</a> that allow us to receive and publish events through http and https transports.This extension only works inside 
-the WSO2 Data Analytic Server and cannot be run with standalone siddhi.
+The **siddhi-io-http extension** is an extension to <a target="_blank" href="https://wso2.github.io/siddhi">Siddhi</a> that allows you to receive and publish events via http and https transports. This extension can work with WSO2 Stream Processor. It can also run with standalone Siddhi.
 
 Find some useful links below:
 
@@ -18,13 +17,13 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 
 **Using the extension in <a target="_blank" href="https://github.com/wso2/product-sp">WSO2 Stream Processor</a>**
 
-* You can use this extension in the latest <a target="_blank" href="https://github.com/wso2/product-sp/releases">WSO2 Stream Processor</a> that is a part of <a target="_blank" href="http://wso2.com/analytics?utm_source=gitanalytics&utm_campaign=gitanalytics_Jul17">WSO2 Analytics</a> offering, with editor, debugger and simulation support. 
+* You can use this extension with the latest <a target="_blank" href="https://github.com/wso2/product-sp/releases">WSO2 Stream Processor</a> that is a part of the <a target="_blank" href="http://wso2.com/analytics?utm_source=gitanalytics&utm_campaign=gitanalytics_Jul17">WSO2 Analytics</a> offering, with editor, debugger and simulation support. 
 
-* This extension is shipped by default with WSO2 Stream Processor, if you wish to use an alternative version of this extension you can replace the component <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-http/releases">jar</a> that can be found in the `<STREAM_PROCESSOR_HOME>/lib` directory.
+* This extension is shipped with WSO2 Stream Processor by default. If you need to use an alternative version of this extension you can replace the component <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-http/releases">jar</a> that can be found in the `<STREAM_PROCESSOR_HOME>/lib` directory with the component jar of the relevant version.
 
 **Using the extension as a <a target="_blank" href="https://wso2.github.io/siddhi/documentation/running-as-a-java-library">java library</a>**
 
-* This extension can be added as a maven dependency along with other Siddhi dependencies to your project.
+* This extension can be added as a maven dependency to your project together with other Siddhi dependencies.
 
 ```
      <dependency>
@@ -46,20 +45,20 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 
 ## Features
 
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-http/api/1.0.18/#http-sink">http</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink">(Sink)</a>)*<br><div style="padding-left: 1em;"><p>This extension publish the HTTP events in any HTTP method  POST, GET, PUT, DELETE  via HTTP or https protocols. As the additional features this component can provide basic authentication as well as user can publish events using custom client truststore files when publishing events via https protocol. And also user can add any number of headers including HTTP_METHOD header for each event dynamically.</p></div>
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-http/api/1.0.18/#http-source">http</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#source">(Source)</a>)*<br><div style="padding-left: 1em;"><p>The HTTP source receives POST requests via HTTP or HTTPS in format such as <code>text</code>, <code>XML</code> and <code>JSON</code>. If required, you can enable basic authentication to ensure that events are received only from users who are authorized to access the service.</p></div>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-http/api/1.0.18/#http-sink">http</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink">(Sink)</a>)*<br><div style="padding-left: 1em;"><p>This extension publishes HTTP events in any HTTP method (i.e., POST, GET, PUT, DELETE)  via HTTP or HTTPS protocols. In addition, this component also provides basic authentication, and allows you to publish events using custom client truststore files when publishing events via the HTTPS protocol. You can also dynamically add any number of headers for each event including the HTTP_METHOD header.</p></div>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-http/api/1.0.18/#http-source">http</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#source">(Source)</a>)*<br><div style="padding-left: 1em;"><p>The HTTP source receives POST requests via HTTP or HTTPS in format such as <code>text</code>, <code>XML</code> or <code>JSON</code>. If required, you can enable basic authentication to ensure that events are received only from users who are authorized to access the service.</p></div>
 
 ## How to Contribute
  
-  * Please report issues at <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-http/issues">GitHub Issue Tracker</a>.
+  * Report issues at <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-http/issues">GitHub Issue Tracker</a>.
   
-  * Send your contributions as pull requests to <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-http/tree/master">master branch</a>. 
+  * Send your contributions as pull requests to the <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-http/tree/master">master branch</a>. 
  
 ## Contact us 
 
  * Post your questions with the <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">"Siddhi"</a> tag in <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">Stackoverflow</a>. 
  
- * Siddhi developers can be contacted via the mailing lists:
+ * Siddhi developers can be contacted via the following mailing lists:
  
     Developers List   : [dev@wso2.org](mailto:dev@wso2.org)
     
@@ -67,8 +66,9 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
  
 ## Support 
 
-* We are committed to ensuring support for this extension in production. Our unique approach ensures that all support 
-leverages our open development methodology and is provided by the very same engineers who build the technology. 
+* We are committed to provide support for this extension in production. Our unique approach ensures that all support 
+leverages our open development methodology, and is provided by the very same engineers who build the technology. 
 
 * For more details and to take advantage of this unique opportunity contact us via <a target="_blank" href="http://wso2
 .com/support?utm_source=gitanalytics&utm_campaign=gitanalytics_Jul17">http://wso2.com/support/</a>. 
+


### PR DESCRIPTION
## Purpose
To clearly mention that the siddhi-io-http extension can be used with the Stream Processor as well as standalone Siddhi.


## Documentation
Edited the readme.md file. Did the correction to the content as discussed with the team, and applied some linguistic corrections.

