### PR TITLE
Add support to send form data as url-encoded values

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -52,12 +52,16 @@ public class HttpConstants {
     public static final String MAP_TEXT = "text";
     public static final String MAP_JSON = "json";
     public static final String MAP_XML = "xml";
+    public static final String MAP_KEYVALUE = "keyvalue";
     public static final String HTTP_CONTENT_TYPE = "Content-Type";
+    public static final String CONTENT_TYPE = "content.type";
     public static final String TEXT_PLAIN = "text/plain";
     public static final String APPLICATION_XML = "application/xml";
     public static final String APPLICATION_JSON = "application/json";
+    public static final String APPLICATION_URL_ENCODED = "application/x-www-form-urlencoded";
     public static final String DEFAULT_ENCODING = "UTF-8";
-    
+    public static final String ENCODE = "encode.payload";
+
     //Common util values
     public static final String HTTP_METHOD_POST = "POST"; //method name
     public static final String HTTP_METHOD = "HTTP_METHOD";
@@ -186,6 +190,8 @@ public class HttpConstants {
     
     public static final String HTTP_TRACE_LOG_ENABLED = "httpTraceLogEnabled";
     public static final String LOG_TRACE_ENABLE_DEFAULT_VALUE = "false";
+
+    public static final String DEFAULT_ENCODE_PAYLOAD_VALUE = "false";
     
     public static final String PARAMETER_SEPARATOR = "','";
     public static final String VALUE_SEPARATOR = ":";

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -54,13 +54,11 @@ public class HttpConstants {
     public static final String MAP_XML = "xml";
     public static final String MAP_KEYVALUE = "keyvalue";
     public static final String HTTP_CONTENT_TYPE = "Content-Type";
-    public static final String CONTENT_TYPE = "content.type";
     public static final String TEXT_PLAIN = "text/plain";
     public static final String APPLICATION_XML = "application/xml";
     public static final String APPLICATION_JSON = "application/json";
     public static final String APPLICATION_URL_ENCODED = "application/x-www-form-urlencoded";
     public static final String DEFAULT_ENCODING = "UTF-8";
-    public static final String ENCODE = "encode.payload";
 
     //Common util values
     public static final String HTTP_METHOD_POST = "POST"; //method name


### PR DESCRIPTION
## Purpose
> $ subject

## Goals
> Providing support to encode payloads as URL encoded parameters and send using http sink.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
