### PR TITLE
Allow query parameters in http sink

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -485,7 +485,7 @@ public class HttpSink extends Sink {
      */
     @Override
     public String[] getSupportedDynamicOptions() {
-        return new String[] {HttpConstants.HEADERS, HttpConstants.METHOD};
+        return new String[] {HttpConstants.HEADERS, HttpConstants.METHOD, HttpConstants.PUBLISHER_URL};
     }
 
     /**
@@ -562,8 +562,8 @@ public class HttpSink extends Sink {
             if (clientConnector != null) {
                 clientConnector.close();
             }
-            initClientConnector(dynamicOptions);
         }
+        initClientConnector(dynamicOptions);
         String headers = httpHeaderOption.getValue(dynamicOptions);
         String httpMethod = EMPTY_STRING.equals(httpMethodOption.getValue(dynamicOptions)) ?
                 HttpConstants.METHOD_DEFAULT : httpMethodOption.getValue(dynamicOptions);

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/util/HttpSinkUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/util/HttpSinkUtil.java
@@ -76,7 +76,7 @@ public class HttpSinkUtil {
         try {
             URL url = new URL(publisherURL);
             httpStaticProperties = new HashMap<>();
-            httpStaticProperties.put(Constants.TO, url.getPath());
+            httpStaticProperties.put(Constants.TO, url.getFile());
             String protocol = url.getProtocol();
             httpStaticProperties.put(Constants.PROTOCOL, protocol);
             httpStaticProperties.put(Constants.HTTP_HOST, url.getHost());


### PR DESCRIPTION
## Purpose
> Allow query parameters in http sink

## Goals
> Fix https://github.com/wso2/siddhi/issues/829

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
