### PR TITLE
Define surefire plugin version explicitly

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -154,6 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>

--- a/pom.xml
+++ b/pom.xml
@@ -456,6 +456,7 @@
         <antlr4.maven.plugin.version>4.2.2</antlr4.maven.plugin.version>
         <maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
         <org.jacoco.version>0.7.9</org.jacoco.version>
+        <surefire.plugin.version>2.22.1</surefire.plugin.version>
     </properties>
     <build>
         <extensions>
@@ -564,7 +565,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>${surefire.plugin.version}</version>
                     <configuration>
                         <includes>
                             <include>**/*TestCase.java</include>

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -227,6 +227,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <systemPropertyVariables>
                                 <org.ops4j.pax.url.mvn.localRepository>${settings.localRepository}


### PR DESCRIPTION
## Purpose
To fix release build failures, as the lower versions of maven is not compatible with the latest surefire plugin version

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes