### PR TITLE
Added solution for siddhi-http-IO access token expired problem

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -96,6 +96,12 @@
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+            <version>3.0.0.wso2v1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -99,8 +99,6 @@
         <dependency>
             <groupId>org.json.wso2</groupId>
             <artifactId>json</artifactId>
-            <version>3.0.0.wso2v1</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
     <profiles>

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -370,8 +370,8 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
                 @Parameter(
                         name = "oauth.username",
                         description = "The username to be included in the authentication header of the oauth " +
-                                "authentication enabled events. It is required to specify both username and" +
-                                "password to enable oauth authentication. If one of the parameter is not given" +
+                                "authentication enabled events. It is required to specify both username and " +
+                                "password to enable oauth authentication. If one of the parameter is not given " +
                                 "by user then an error is logged in the CLI. It is only applicable for for Oauth" +
                                 " requests ",
                         type = {DataType.STRING},
@@ -380,9 +380,9 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
                 @Parameter(
                         name = "oauth.password",
                         description = "The password to be included in the authentication header of the oauth " +
-                                "authentication enabled events. It is required to specify both username and" +
-                                "password to enable oauth authentication. If one of the parameter is not given" +
-                                "by user then an error is logged in the CLI. It is only applicable for for Oauth" +
+                                "authentication enabled events. It is required to specify both username and " +
+                                "password to enable oauth authentication. If one of the parameter is not given " +
+                                "by user then an error is logged in the CLI. It is only applicable for for Oauth " +
                                 " requests ",
                         type = {DataType.STRING},
                         optional = true,
@@ -568,14 +568,14 @@ public class HttpRequestSink extends HttpSink {
             log.info("Request sent successfully to " + publisherURL);
         } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
             log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                    response + "- Internal server error.");
+                    response + "- Internal server error. Message dropped.");
             throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint: " +
-                    publisherURL + "', with response code: " + response + "- Internal server error.");
+                    publisherURL + "', with response code: " + response + "- Internal server error. Message dropped.");
         } else {
             log.error("Error at sending oauth request to API endpoint: " +
-                    publisherURL + "', with response code: " + response);
+                    publisherURL + "', with response code: " + response + ". Message dropped. Message dropped.");
             throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint: " +
-                    publisherURL + "', with response code: " + response);
+                    publisherURL + "', with response code: " + response + ". Message dropped. Message dropped.");
         }
     }
 
@@ -607,14 +607,14 @@ public class HttpRequestSink extends HttpSink {
             requestForNewAccessToken(payload, dynamicOptions, headersList, encodedAuth);
         } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
             log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                    response + "- Internal server error.");
+                    response + "- Internal server error. Message dropped.");
             throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint " +
-                    publisherURL + "', with response code: " + response + "- Internal server error.");
+                    publisherURL + "', with response code: " + response + "- Internal server error. Message dropped.");
         } else {
             log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                    response);
+                    response + ". Message dropped. ");
             throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint " +
-                    publisherURL + "', with response code: " + response);
+                    publisherURL + "', with response code: " + response + ". Message dropped.");
         }
     }
 
@@ -649,34 +649,37 @@ public class HttpRequestSink extends HttpSink {
             } else if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
                 log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
                         response + "- Authentication Failure. " +
-                        "Please provide a valid Consumer key and a Consumer secret.");
+                        "Please provide a valid Consumer key and a Consumer secret. Message dropped.");
                 throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint " +
                         publisherURL + "', with response code: " + response + "- Authentication Failure. " +
-                        "Please provide a valid Consumer key and a Consumer secret.");
+                        "Please provide a valid Consumer key and a Consumer secret. Message dropped.");
             } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
                 log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                        response + "- Internal server error.");
+                        response + "- Internal server error. Message dropped.");
                 throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint " +
-                        publisherURL + "', with response code:" + response + "- Internal server error.");
+                        publisherURL + "', with response code:" + response +
+                        "- Internal server error. Message dropped.");
             } else {
                 log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                        response);
+                        response + ". Message dropped.");
                 throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint  " +
-                        publisherURL + "', with response code: " + response);
+                        publisherURL + "', with response code: " + response + ". Message dropped.");
             }
 
         } else if (accessTokenCache.getResponseCode(encodedAuth) == HttpConstants.AUTHENTICATION_FAIL_CODE) {
             log.error("Failed to generate new access token for the expired access token to " + publisherURL + "', " +
                     accessTokenCache.getResponseCode(encodedAuth) + ": Authentication Failure. Please provide a valid" +
-                    " Consumer key and a Consumer secret.");
+                    " Consumer key and a Consumer secret. Message dropped.");
             throw new HttpSinkAdaptorRuntimeException("Failed to generate new access token for the expired access " +
                     "token to " + publisherURL + "', " + accessTokenCache.getResponseCode(encodedAuth) +
-                    ": Authentication Failure. Please provide a valid Consumer key and a Consumer secret.");
+                    ": Authentication Failure. Please provide a valid Consumer key and a Consumer secret." +
+                    " Message dropped.");
         } else {
             log.error("Failed to generate new access token for the expired access token. Error code: " +
-                    accessTokenCache.getResponseCode(encodedAuth));
+                    accessTokenCache.getResponseCode(encodedAuth) + ". Message dropped.");
             throw new HttpSinkAdaptorRuntimeException("Failed to generate new access token for the expired" +
-                    " access token. Error code: " + accessTokenCache.getResponseCode(encodedAuth));
+                    " access token. Error code: " + accessTokenCache.getResponseCode(encodedAuth) +
+                    ". Message dropped.");
         }
     }
 
@@ -707,14 +710,15 @@ public class HttpRequestSink extends HttpSink {
             try {
                 boolean latchCount = latch.await(30, TimeUnit.SECONDS);
                 if (!latchCount) {
-                    log.debug("Time out due to getting getting response from " + publisherURL);
+                    log.debug("Time out due to getting getting response from " + publisherURL + ". Message dropped.");
                     throw new HttpSinkAdaptorRuntimeException("Time out due to getting getting response from "
-                            + publisherURL);
+                            + publisherURL + ". Message dropped.");
+
                 }
             } catch (InterruptedException e) {
-                log.debug("Failed to get a response from " + publisherURL + "," + e);
+                log.debug("Failed to get a response from " + publisherURL + "," + e + ". Message dropped.");
                 throw new HttpSinkAdaptorRuntimeException("Failed to get a response from " +
-                        publisherURL + ", " + e);
+                        publisherURL + ", " + e + ". Message dropped.");
             }
         }
         HTTPCarbonMessage response = httpListener.getHttpResponseMessage();

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -671,7 +671,10 @@ public class HttpRequestSink extends HttpSink {
         httpResponseFuture.setHttpConnectorListener(httpListener);
         if (HttpConstants.OAUTH.equals(authType)) {
             try {
-                latch.await(30, TimeUnit.SECONDS);
+                boolean latchCount = latch.await(30, TimeUnit.SECONDS);
+                if (!latchCount) {
+                    log.debug("Time out due to getting new access token. ");
+                }
             } catch (InterruptedException e) {
                 log.debug("Time out due to getting new access token. " + e);
             }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -367,19 +367,42 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
                         optional = true,
                         defaultValue = "null",
                         dynamic = true),
-                //added
                 @Parameter(
-                        name = "client.consumerkey",
-                        description = "The consumer key for getting refresh token.",
+                        name = "oauth.username",
+                        description = "The username to be included in the authentication header of the oauth" +
+                                "authentication enabled events. It is required to specify both username and" +
+                                "password to enable oauth authentication. If one of the parameter is not given" +
+                                "by user then an error is logged in the CLI ",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = "null"),
+                        defaultValue = " "),
                 @Parameter(
-                        name = "client.consumer.secret",
-                        description = "The consumer secret key for getting refresh token.",
+                        name = "oauth.password",
+                        description = "The password to be included in the authentication header of the oauth" +
+                                "authentication enabled events. It is required to specify both username and" +
+                                "password to enable oauth authentication. If one of the parameter is not given" +
+                                "by user then an error is logged in the CLI ",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = "null"),
+                        defaultValue = " "),
+                @Parameter(
+                        name = "consumer.key",
+                        description = "consumer key for the Http request",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = " "),
+                @Parameter(
+                        name = "consumer.secret",
+                        description = "consumer secret for the Http request",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = " "),
+                @Parameter(
+                        name = "refresh.token",
+                        description = "refresh token for the Http request",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = " "),
         },
         examples = {
                 @Example(syntax =

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -18,14 +18,16 @@
  */
 package org.wso2.extension.siddhi.io.http.sink;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.base64.Base64;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
-
 import org.apache.log4j.Logger;
 import org.wso2.carbon.messaging.Header;
+import org.wso2.extension.siddhi.io.http.sink.updatetoken.AccessTokenCache;
 import org.wso2.extension.siddhi.io.http.sink.util.HttpSinkUtil;
 import org.wso2.extension.siddhi.io.http.source.HttpResponseMessageListener;
 import org.wso2.extension.siddhi.io.http.util.HttpConstants;
@@ -46,9 +48,13 @@ import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
 
@@ -140,6 +146,7 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = "POST"),
+
                 @Parameter(
                         name = "socket.idle.timeout",
                         description = "Socket timeout value in millisecond",
@@ -360,10 +367,23 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
                         optional = true,
                         defaultValue = "null",
                         dynamic = true),
+                //added
+                @Parameter(
+                        name = "client.consumerkey",
+                        description = "The consumer key for getting refresh token.",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = "null"),
+                @Parameter(
+                        name = "client.consumer.secret",
+                        description = "The consumer secret key for getting refresh token.",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = "null"),
         },
         examples = {
                 @Example(syntax =
-                                "@sink(type='http-request', sink.id='foo', " +
+                        "@sink(type='http-request', sink.id='foo', " +
                                 "publisher.url='http://localhost:8009/foo', " +
                                 "@map(type='xml', @payload('{{payloadBody}}')))\n" +
                                 "define stream FooStream (payloadBody String, method string, headers string);\n" +
@@ -379,61 +399,61 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
                                 "define stream responseStream4xx(errorMsg string);",
                         description =
                                 "In above example, the payload body for 'FooStream' will be in following " +
-                                "format.\n" +
-                                "{\n" +
-                                "<events>\n" +
-                                "    <event>\n" +
-                                "        <symbol>WSO2</symbol>\n" +
-                                "        <price>55.6</price>\n" +
-                                "        <volume>100</volume>\n" +
-                                "    </event>\n" +
-                                "</events>,\n" +
-                                "This message will sent as the body of a POST request with the content-type " +
-                                "'application/xml' to the endpoint defined as the 'publisher.url' and in order to " +
-                                "process the responses for these requests, there should be a source of type " +
-                                "'http-response' defined with the same sink id 'foo' in the siddhi app.\n" +
-                                "The responses with 2xx status codes will be received by the " +
-                                "http-response source which has the http.status.code defined by the regex " +
-                                "'2\\\\d+'.\n" +
-                                "If the response has a 4xx status code, it will be received by the " +
-                                "http-response source which has the http.status.code defined by the regex " +
-                                "'4\\\\d+'.\n"),
+                                        "format.\n" +
+                                        "{\n" +
+                                        "<events>\n" +
+                                        "    <event>\n" +
+                                        "        <symbol>WSO2</symbol>\n" +
+                                        "        <price>55.6</price>\n" +
+                                        "        <volume>100</volume>\n" +
+                                        "    </event>\n" +
+                                        "</events>,\n" +
+                                        "This message will sent as the body of a POST request with the content-type " +
+                                        "'application/xml' to the endpoint defined as the 'publisher.url' and in " +
+                                        "order to process the responses for these requests, there should be a source " +
+                                        "of type 'http-response' defined with the same sink id 'foo' in the siddhi " +
+                                        "app.\n The responses with 2xx status codes will be received by the " +
+                                        "http-response source which has the http.status.code defined by the regex " +
+                                        "'2\\\\d+'.\n" +
+                                        "If the response has a 4xx status code, it will be received by the " +
+                                        "http-response source which has the http.status.code defined by the regex " +
+                                        "'4\\\\d+'.\n"),
 
                 @Example(syntax = "" +
-                                "define stream FooStream (name String, id int, headers String, downloadPath string);" +
-                                "\n" +
-                                "@sink(type='http-request', \n" +
-                                "downloading.enabled='true',\n" +
-                                "download.path='{{downloadPath}}'," +
-                                "publisher.url='http://localhost:8005/files',\n" +
-                                "method='GET', " +
-                                "headers='{{headers}}',sink.id='download-sink',\n" +
-                                "@map(type='json')) \n" +
-                                "define stream BarStream (name String, id int, headers String, downloadPath string);" +
-                                "\n\n" +
-                                "@source(type='http-response', sink.id='download-sink', " +
-                                "http.status.code='2\\\\d+', \n" +
-                                "@map(type='text', regex.A='((.|\\n)*)', " +
-                                "@attributes(headers='trp:headers', fileName='A[1]')))\n" +
-                                "define stream responseStream2xx(fileName string, headers string);\n\n" +
-                                "" +
-                                "@source(type='http-response', sink.id='download-sink', " +
-                                "http.status.code='4\\\\d+', \n" +
-                                "@map(type='text', regex.A='((.|\\n)*)', @attributes(errorMsg='A[1]')))\n" +
-                                "define stream responseStream4xx(errorMsg string);",
+                        "define stream FooStream (name String, id int, headers String, downloadPath string);" +
+                        "\n" +
+                        "@sink(type='http-request', \n" +
+                        "downloading.enabled='true',\n" +
+                        "download.path='{{downloadPath}}'," +
+                        "publisher.url='http://localhost:8005/files',\n" +
+                        "method='GET', " +
+                        "headers='{{headers}}',sink.id='download-sink',\n" +
+                        "@map(type='json')) \n" +
+                        "define stream BarStream (name String, id int, headers String, downloadPath string);" +
+                        "\n\n" +
+                        "@source(type='http-response', sink.id='download-sink', " +
+                        "http.status.code='2\\\\d+', \n" +
+                        "@map(type='text', regex.A='((.|\\n)*)', " +
+                        "@attributes(headers='trp:headers', fileName='A[1]')))\n" +
+                        "define stream responseStream2xx(fileName string, headers string);\n\n" +
+                        "" +
+                        "@source(type='http-response', sink.id='download-sink', " +
+                        "http.status.code='4\\\\d+', \n" +
+                        "@map(type='text', regex.A='((.|\\n)*)', @attributes(errorMsg='A[1]')))\n" +
+                        "define stream responseStream4xx(errorMsg string);",
                         description =
                                 "In above example, http-request sink will send a GET request to the publisher url and" +
-                                " the requested file will be received as the response by a corresponding " +
-                                "http-response source.\n" +
-                                "If the http status code of the response is a successful one (2xx), it will " +
-                                "be received by the http-response source which has the http.status.code " +
-                                "'2\\\\d+' and downloaded as a local file. Then the event received to the " +
-                                "responseStream2xx will have the headers included in the request and " +
-                                "the downloaded file name.\n" +
-                                "If the http status code of the response is a 4xx code, it will be received " +
-                                "by the http-response source which has the http.status.code '4\\\\d+'. Then " +
-                                "the event received to the responseStream4xx will have the response message " +
-                                "body in text format."
+                                        " the requested file will be received as the response by a corresponding " +
+                                        "http-response source.\n" +
+                                        "If the http status code of the response is a successful one (2xx), it will " +
+                                        "be received by the http-response source which has the http.status.code " +
+                                        "'2\\\\d+' and downloaded as a local file. Then the event received to the " +
+                                        "responseStream2xx will have the headers included in the request and " +
+                                        "the downloaded file name.\n" +
+                                        "If the http status code of the response is a 4xx code, it will be received " +
+                                        "by the http-response source which has the http.status.code '4\\\\d+'. Then " +
+                                        "the event received to the responseStream4xx will have the response message " +
+                                        "body in text format."
                 )}
 )
 public class HttpRequestSink extends HttpSink {
@@ -443,18 +463,48 @@ public class HttpRequestSink extends HttpSink {
     private boolean isDownloadEnabled;
     private StreamDefinition outputStreamDefinition;
     private Option downloadPath;
+    private Option publisherURLOption;
+    private String consumerKey;
+    private String consumerSecret;
+    private String authType;
+    private String availableRefreshToken;
+    private String accessToken;
+    private AccessTokenCache accessTokenCache = new AccessTokenCache();
 
     @Override
     protected void init(StreamDefinition outputStreamDefinition, OptionHolder optionHolder,
                         ConfigReader configReader, SiddhiAppContext siddhiAppContext) {
         super.init(outputStreamDefinition, optionHolder, configReader, siddhiAppContext);
+
         this.sinkId = optionHolder.validateAndGetStaticValue(HttpConstants.SINK_ID);
         this.isDownloadEnabled = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(HttpConstants
                 .DOWNLOAD_ENABLED, HttpConstants.DEFAULT_DOWNLOAD_ENABLED_VALUE));
         if (isDownloadEnabled) {
             this.downloadPath = optionHolder.validateAndGetOption(HttpConstants.DOWNLOAD_PATH);
         }
+        String userName = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_USERNAME, EMPTY_STRING);
+        String userPassword = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_PASSWORD, EMPTY_STRING);
+        this.consumerKey = optionHolder.validateAndGetStaticValue(HttpConstants.CONSUMER_KEY, EMPTY_STRING);
+        this.consumerSecret = optionHolder.validateAndGetStaticValue(HttpConstants.CONSUMER_SECRET, EMPTY_STRING);
         this.outputStreamDefinition = outputStreamDefinition;
+        String oauthUsername = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_OAUTH_USERNAME,
+                EMPTY_STRING);
+        this.publisherURLOption = optionHolder.validateAndGetOption(HttpConstants.PUBLISHER_URL);
+        String oauthUserPassword = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_OAUTH_PASSWORD,
+                EMPTY_STRING);
+
+
+        if (!HttpConstants.EMPTY_STRING.equals(userName) && !HttpConstants.EMPTY_STRING.equals(userPassword)) {
+            authType = HttpConstants.BASIC_AUTH;
+        } else if ((!HttpConstants.EMPTY_STRING.equals(consumerKey)
+                && !HttpConstants.EMPTY_STRING.equals(consumerSecret)) ||
+                (!HttpConstants.EMPTY_STRING.equals(oauthUsername)
+                        && !HttpConstants.EMPTY_STRING.equals(oauthUserPassword))) {
+            authType = HttpConstants.OAUTH;
+        } else {
+            authType = HttpConstants.NO_AUTH;
+        }
+
     }
 
 
@@ -466,13 +516,120 @@ public class HttpRequestSink extends HttpSink {
      */
     @Override
     public void publish(Object payload, DynamicOptions dynamicOptions) {
+//get the dynamic parameter
+        String headers = httpHeaderOption.getValue(dynamicOptions);
+        List<Header> headersList = HttpSinkUtil.getHeaders(headers);
+
+        if (authType.equals(HttpConstants.BASIC_AUTH) || authType.equals(HttpConstants.NO_AUTH)) {
+            sendRequest(payload, dynamicOptions, headersList, HttpConstants.MAXIMUM_TRY_COUNT);
+        } else {
+            sendOauthRequest(payload, dynamicOptions, headersList);
+        }
+        disconnect();
+    }
+
+    private void sendOauthRequest(Object payload, DynamicOptions dynamicOptions, List<Header> headersList) {
+        //generate encoded base64 auth for getting refresh token
+        String consumerKeyValue = consumerKey + ":" + consumerSecret;
+        String encodedRefreshAuth = "Basic " + encodeBase64(consumerKeyValue);
+        //check the availability of access token in the header
+        checkAccessToken(encodedRefreshAuth, dynamicOptions, headersList);
+        //send a request to API and get the response
+        int response = sendRequest(payload, dynamicOptions, headersList, HttpConstants.MINIMUM_TRY_COUNT);
+        //if authentication fails then get the new access token
+        if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+            oauthFails(payload, dynamicOptions, headersList, encodedRefreshAuth);
+        } else if (response == HttpConstants.SUCCESS_CODE) {
+            log.info("Request send successfully.");
+        } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
+            log.error(response + ": Internal server error.");
+        } else {
+            log.error(response + ": Can not obtain access token.");
+        }
+    }
+
+    private void oauthFails(Object payload, DynamicOptions dynamicOptions, List<Header> headersList,
+                            String encodedRefreshAuth) {
+
+        Boolean checkFromCache = accessTokenCache.checkAvailableKey(encodedRefreshAuth);
+        if (checkFromCache) {
+            getNewAccessTokenWithCache(payload, dynamicOptions, headersList, encodedRefreshAuth);
+        } else {
+            requestForNewAccessToken(payload, dynamicOptions, headersList, encodedRefreshAuth);
+        }
+    }
+
+    private void getNewAccessTokenWithCache(Object payload, DynamicOptions dynamicOptions, List<Header> headersList,
+                                            String encodedRefreshAuth) {
+        accessToken = accessTokenCache.getAccessToken(encodedRefreshAuth);
+        for (Header header : headersList) {
+            if (header.getName().equals(HttpConstants.AUTHORIZATION_HEADER)) {
+                header.setValue(accessToken);
+            }
+        }
+        //send a request to API with a new access token
+        int response = sendRequest(payload, dynamicOptions, headersList, HttpConstants.MINIMUM_TRY_COUNT);
+        if (response == HttpConstants.SUCCESS_CODE) {
+            log.info("Request send successfully.");
+        } else if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+            requestForNewAccessToken(payload, dynamicOptions, headersList, encodedRefreshAuth);
+        } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
+            log.error(response + ": Internal server error.");
+        } else {
+            log.error(response + ": Can not obtain access token.");
+        }
+    }
+
+    private void requestForNewAccessToken(Object payload, DynamicOptions dynamicOptions, List<Header> headersList,
+                                               String encodedRefreshAuth) {
+        Boolean checkRefreshToken = accessTokenCache.checkRefreshAvailableKey(encodedRefreshAuth);
+        if (checkRefreshToken) {
+            availableRefreshToken = accessTokenCache.getRefreshtoken(encodedRefreshAuth);
+            for (Header header : headersList) {
+                if (header.getName().equals(HttpConstants.RECEIVER_REFRESH_TOKEN)) {
+                    header.setValue(availableRefreshToken);
+                }
+            }
+        }
+        ArrayList<String> newAccessTokenArray = getAccessToken(dynamicOptions, encodedRefreshAuth);
+        int newAccessResponseCode = Integer.parseInt(newAccessTokenArray.get(0));
+        if (newAccessResponseCode == HttpConstants.SUCCESS_CODE) {
+            String newAccessToken = "Bearer " + newAccessTokenArray.get(1);
+            accessTokenCache.setAccessToken(encodedRefreshAuth, newAccessToken);
+            if (!newAccessTokenArray.get(2).equals(HttpConstants.EMPTY_STRING)) {
+                accessTokenCache.setRefreshtoken(encodedRefreshAuth, newAccessTokenArray.get(2));
+            }
+            for (Header header : headersList) {
+                if (header.getName().equals(HttpConstants.AUTHORIZATION_HEADER)) {
+                    header.setValue(newAccessToken);
+                }
+            }
+            //send a request to API with a new access token
+            int response = sendRequest(payload, dynamicOptions, headersList, HttpConstants.MAXIMUM_TRY_COUNT);
+            if (response == HttpConstants.SUCCESS_CODE) {
+                log.info("Request send successfully.");
+            } else if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+                log.error(response + ": Authentication Failure. Please apply valid authorization.");
+            } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
+                log.error(response + ": Internal server error.");
+            } else {
+                log.error(response + ": Can not obtain access token.");
+            }
+
+        } else if (newAccessResponseCode == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+            log.error(newAccessResponseCode + ": Authentication Failure. Please apply valid Consumer key, " +
+                    "Consumer secret for generate new access token. ");
+        } else {
+            log.error(newAccessResponseCode + ": Can not obtain new access token.");
+        }
+    }
+
+    private int sendRequest(Object payload, DynamicOptions dynamicOptions, List<Header> headersList, int tryCount) {
         if (!publisherURLOption.isStatic()) {
             super.initClientConnector(dynamicOptions);
         }
-        String headers = httpHeaderOption.getValue(dynamicOptions);
         String httpMethod = EMPTY_STRING.equals(httpMethodOption.getValue(dynamicOptions)) ?
                 HttpConstants.METHOD_DEFAULT : httpMethodOption.getValue(dynamicOptions);
-        List<Header> headersList = HttpSinkUtil.getHeaders(headers);
         String contentType = HttpSinkUtil.getContentType(mapType, headersList);
         String messageBody = getMessageBody(payload);
         HttpMethod httpReqMethod = new HttpMethod(httpMethod);
@@ -485,15 +642,27 @@ public class HttpRequestSink extends HttpSink {
         }
         cMessage.completeMessage();
         HttpResponseFuture httpResponseFuture = clientConnector.send(cMessage);
+        CountDownLatch latch = new CountDownLatch(1);
         HttpResponseMessageListener httpListener =
-                new HttpResponseMessageListener(getTrpProperties(dynamicOptions), sinkId, isDownloadEnabled);
+                new HttpResponseMessageListener(getTrpProperties(dynamicOptions), sinkId, isDownloadEnabled, latch,
+                        tryCount, authType);
         httpResponseFuture.setHttpConnectorListener(httpListener);
+        if (HttpConstants.OAUTH.equals(authType)) {
+            try {
+                latch.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                log.debug("Time out due to getting new access token. " + e);
+                disconnect();
+            }
+        }
+        HTTPCarbonMessage response = httpListener.getHttpResponseMessage();
+        return response.getNettyHttpResponse().status().code();
     }
 
     @Override
     public String[] getSupportedDynamicOptions() {
-        return new String[] {HttpConstants.HEADERS, HttpConstants.METHOD,
-                HttpConstants.DOWNLOAD_PATH, HttpConstants.PUBLISHER_URL};
+        return new String[]{HttpConstants.HEADERS, HttpConstants.METHOD, HttpConstants.PUBLISHER_URL,
+                HttpConstants.DOWNLOAD_PATH, HttpConstants.PUBLISHER_URL, HttpConstants.RECEIVER_REFRESH_TOKEN};
     }
 
     private Map<String, Object> getTrpProperties(DynamicOptions dynamicOptions) {
@@ -508,5 +677,12 @@ public class HttpRequestSink extends HttpSink {
             trpProperties.put(HttpConstants.DOWNLOAD_PATH, downloadPath.getValue(dynamicOptions));
         }
         return trpProperties;
+    }
+
+    private String encodeBase64(String consumerKeyValue) {
+
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(consumerKeyValue.getBytes(StandardCharsets.UTF_8));
+        ByteBuf encodedByteBuf = Base64.encode(byteBuf);
+        return encodedByteBuf.toString(StandardCharsets.UTF_8);
     }
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -525,7 +525,6 @@ public class HttpRequestSink extends HttpSink {
         } else {
             sendOauthRequest(payload, dynamicOptions, headersList);
         }
-        disconnect();
     }
 
     private void sendOauthRequest(Object payload, DynamicOptions dynamicOptions, List<Header> headersList) {
@@ -652,7 +651,6 @@ public class HttpRequestSink extends HttpSink {
                 latch.await(30, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 log.debug("Time out due to getting new access token. " + e);
-                disconnect();
             }
         }
         HTTPCarbonMessage response = httpListener.getHttpResponseMessage();

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -18,6 +18,7 @@
  */
 package org.wso2.extension.siddhi.io.http.sink;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.base64.Base64;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -25,9 +26,11 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
-
 import org.apache.log4j.Logger;
 import org.wso2.carbon.messaging.Header;
+import org.wso2.extension.siddhi.io.http.sink.updatetoken.AccessTokenCache;
+import org.wso2.extension.siddhi.io.http.sink.updatetoken.DefaultListener;
+import org.wso2.extension.siddhi.io.http.sink.updatetoken.HttpsClient;
 import org.wso2.extension.siddhi.io.http.sink.util.HttpSinkUtil;
 import org.wso2.extension.siddhi.io.http.util.HttpConstants;
 import org.wso2.extension.siddhi.io.http.util.HttpIoUtil;
@@ -37,7 +40,6 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.SystemParameter;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
-import org.wso2.siddhi.core.exception.ConnectionUnavailableException;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
 import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.stream.output.sink.Sink;
@@ -51,6 +53,7 @@ import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.config.ChunkConfig;
 import org.wso2.transport.http.netty.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -59,9 +62,13 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.PORT_HOST_SEPARATOR;
@@ -435,14 +442,16 @@ public class HttpSink extends Sink {
     private String streamID;
     HttpClientConnector clientConnector;
     String mapType;
-    private Map<String, String> httpURLProperties;
+    private static Map<String, String> httpURLProperties;
     Option httpHeaderOption;
     Option httpMethodOption;
+    private String consumerKey;
+    private String consumerSecret;
     private String authorizationHeader;
     private String userName;
     private String userPassword;
     private String publisherURL;
-    Option publisherURLOption;
+    private Option publisherURLOption;
     private String clientStoreFile;
     private String clientStorePass;
     private int socketIdleTimeout;
@@ -463,8 +472,15 @@ public class HttpSink extends Sink {
     private String bootstrapClient;
     private ConfigReader configReader;
     private SiddhiAppContext siddhiAppContext;
+    private String oauthUsername;
+    private String oauthUserPassword;
+    private String accessToken;
+    private Option refreshToken;
+    private String availableRefreshToken;
+    private String authType;
+    private Boolean accesstokenAvalable = false;
+    private AccessTokenCache accessTokenCache = new AccessTokenCache();
 
-    private HttpWsConnectorFactory httpConnectorFactory;
 
     /**
      * Returns the list of classes which this sink can consume.
@@ -476,7 +492,7 @@ public class HttpSink extends Sink {
      */
     @Override
     public Class[] getSupportedInputEventClasses() {
-        return new Class[] {String.class, Map.class};
+        return new Class[]{String.class, Map.class};
     }
 
     /**
@@ -487,7 +503,8 @@ public class HttpSink extends Sink {
      */
     @Override
     public String[] getSupportedDynamicOptions() {
-        return new String[] {HttpConstants.HEADERS, HttpConstants.METHOD, HttpConstants.PUBLISHER_URL};
+        return new String[]{HttpConstants.HEADERS, HttpConstants.METHOD, HttpConstants.PUBLISHER_URL,
+                HttpConstants.RECEIVER_REFRESH_TOKEN};
     }
 
     /**
@@ -513,8 +530,15 @@ public class HttpSink extends Sink {
         this.publisherURLOption = optionHolder.validateAndGetOption(HttpConstants.PUBLISHER_URL);
         this.httpHeaderOption = optionHolder.getOrCreateOption(HttpConstants.HEADERS, HttpConstants.DEFAULT_HEADER);
         this.httpMethodOption = optionHolder.getOrCreateOption(HttpConstants.METHOD, HttpConstants.DEFAULT_METHOD);
+        this.consumerKey = optionHolder.validateAndGetStaticValue(HttpConstants.CONSUMER_KEY, EMPTY_STRING);
+        this.consumerSecret = optionHolder.validateAndGetStaticValue(HttpConstants.CONSUMER_SECRET, EMPTY_STRING);
         this.userName = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_USERNAME, EMPTY_STRING);
         this.userPassword = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_PASSWORD, EMPTY_STRING);
+        this.oauthUsername = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_OAUTH_USERNAME,
+                EMPTY_STRING);
+        this.oauthUserPassword = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_OAUTH_PASSWORD,
+                EMPTY_STRING);
+        this.refreshToken = optionHolder.getOrCreateOption(HttpConstants.RECEIVER_REFRESH_TOKEN, EMPTY_STRING); //todo
         clientStoreFile = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_TRUSTSTORE_PATH_PARAM,
                 HttpSinkUtil.trustStorePath(configReader));
         clientStorePass = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_TRUSTSTORE_PASSWORD_PARAM,
@@ -532,7 +556,7 @@ public class HttpSink extends Sink {
         proxyHost = optionHolder.validateAndGetStaticValue(HttpConstants.PROXY_HOST, EMPTY_STRING);
         proxyPort = optionHolder.validateAndGetStaticValue(HttpConstants.PROXY_PORT, EMPTY_STRING);
         proxyUsername = optionHolder.validateAndGetStaticValue(HttpConstants.PROXY_USERNAME,
-                 EMPTY_STRING);
+                EMPTY_STRING);
         proxyPassword = optionHolder.validateAndGetStaticValue(HttpConstants.PROXY_PASSWORD,
                 EMPTY_STRING);
         clientBootstrapConfiguration = optionHolder
@@ -546,9 +570,19 @@ public class HttpSink extends Sink {
         bootstrapClient = configReader.readConfig(HttpConstants.CLIENT_BOOTSTRAP_CLIENT_GROUP_SIZE,
                 EMPTY_STRING);
 
-        initConnectorFactory();
         if (publisherURLOption.isStatic()) {
             initClientConnector(null);
+        }
+
+        if (!HttpConstants.EMPTY_STRING.equals(userName) && !HttpConstants.EMPTY_STRING.equals(userPassword)) {
+            authType = HttpConstants.BASIC_AUTH;
+        } else if ((!HttpConstants.EMPTY_STRING.equals(consumerKey)
+                && !HttpConstants.EMPTY_STRING.equals(consumerSecret)) ||
+                (!HttpConstants.EMPTY_STRING.equals(oauthUsername)
+                        && !HttpConstants.EMPTY_STRING.equals(oauthUserPassword))) {
+            authType = HttpConstants.OAUTH;
+        } else {
+            authType = HttpConstants.NO_AUTH;
         }
     }
 
@@ -561,13 +595,189 @@ public class HttpSink extends Sink {
      */
     @Override
     public void publish(Object payload, DynamicOptions dynamicOptions) {
-        if (!publisherURLOption.isStatic()) {
-            initClientConnector(dynamicOptions);
-        }
+        //get the dynamic parameter
         String headers = httpHeaderOption.getValue(dynamicOptions);
+        List<Header> headersList = HttpSinkUtil.getHeaders(headers);
+
+        if (authType.equals(HttpConstants.BASIC_AUTH) || authType.equals(HttpConstants.NO_AUTH)) {
+            sendRequest(payload, dynamicOptions, headersList);
+        } else {
+            sendOauthRequest(payload, dynamicOptions, headersList);
+        }
+        disconnect();
+    }
+
+    private void sendOauthRequest(Object payload, DynamicOptions dynamicOptions, List<Header> headersList) {
+        //generate encoded base64 auth for getting refresh token
+        String consumerKeyValue = consumerKey + ":" + consumerSecret;
+        String encodedRefreshAuth = "Basic " + encodeBase64(consumerKeyValue);
+        //check the availability of access token in the header
+        checkAccessToken(encodedRefreshAuth, dynamicOptions, headersList);
+        //send a request to API and get the response
+        int response = sendRequest(payload, dynamicOptions, headersList);
+        //if authentication fails then get the new access token
+        if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+            oauthFails(payload, dynamicOptions, headersList, encodedRefreshAuth);
+        } else if (response == HttpConstants.SUCCESS_CODE) {
+            log.info("Request send successfully.");
+        } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
+            log.error(response + ": Internal server connection failure. Please pass the valid parameters. ");
+        } else {
+            log.error(response + ": Can not obtain access token.");
+        }
+    }
+
+    private void oauthFails(Object payload, DynamicOptions dynamicOptions, List<Header> headersList,
+                            String encodedRefreshAuth) {
+        Boolean checkFromCache = accessTokenCache.checkAvailableKey(encodedRefreshAuth);
+        if (checkFromCache) {
+            getNewAccessTokenWithCache(payload, dynamicOptions, headersList, encodedRefreshAuth);
+        } else {
+            requestForNewAccessToken(payload, dynamicOptions, headersList, encodedRefreshAuth);
+        }
+    }
+
+    private void getNewAccessTokenWithCache(Object payload, DynamicOptions dynamicOptions, List<Header> headersList,
+                                            String encodedRefreshAuth) {
+        accessToken = accessTokenCache.getAccessToken(encodedRefreshAuth);
+        for (Header header : headersList) {
+            if (header.getName().equals(HttpConstants.AUTHORIZATION_HEADER)) {
+                header.setValue(accessToken);
+            }
+        }
+        //send a request to API with a new access token
+        int response = sendRequest(payload, dynamicOptions, headersList);
+        if (response == HttpConstants.SUCCESS_CODE) {
+            log.info("Request send successfully.");
+        } else if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+            requestForNewAccessToken(payload, dynamicOptions, headersList, encodedRefreshAuth);
+        } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
+            log.error(response + ": Internal server error.");
+        } else {
+            log.error(response + ": Can not obtain access token.");
+        }
+    }
+
+    private void requestForNewAccessToken(Object payload, DynamicOptions dynamicOptions, List<Header> headersList,
+                                               String encodedRefreshAuth) {
+        Boolean checkRefreshToken = accessTokenCache.checkRefreshAvailableKey(encodedRefreshAuth);
+        if (checkRefreshToken) {
+            availableRefreshToken = accessTokenCache.getRefreshtoken(encodedRefreshAuth);
+            for (Header header : headersList) {
+                if (header.getName().equals(HttpConstants.RECEIVER_REFRESH_TOKEN)) {
+                    header.setValue(availableRefreshToken);
+                }
+            }
+        }
+        ArrayList<String> newAccessTokenArray = getAccessToken(dynamicOptions, encodedRefreshAuth);
+        int newAccessResponseCode = Integer.parseInt(newAccessTokenArray.get(0));
+        if (newAccessResponseCode == HttpConstants.SUCCESS_CODE) {
+            String newAccessToken = "Bearer " + newAccessTokenArray.get(1);
+            accessTokenCache.setAccessToken(encodedRefreshAuth, newAccessToken);
+            if (!newAccessTokenArray.get(2).equals(HttpConstants.EMPTY_STRING)) {
+                accessTokenCache.setRefreshtoken(encodedRefreshAuth, newAccessTokenArray.get(2));
+            }
+            for (Header header : headersList) {
+                if (header.getName().equals(HttpConstants.AUTHORIZATION_HEADER)) {
+                    header.setValue(newAccessToken);
+                }
+            }
+            //send a request to API with a new access token
+            int response = sendRequest(payload, dynamicOptions, headersList);
+            if (response == HttpConstants.SUCCESS_CODE) {
+                log.info("Request send successfully.");
+            } else if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+                log.error(response + ": Authentication Failure. Please apply valid authorization.");
+            } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
+                log.error(response + ": Internal server error.");
+            } else {
+                log.error(response + ": Can not obtain new access token.");
+            }
+
+        } else if (newAccessResponseCode == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+            log.error(newAccessResponseCode + ": Authentication Failure. Please apply valid Consumer key, " +
+                    "Consumer secret for generate new access token. ");
+        } else {
+            log.error(newAccessResponseCode + ": Can not obtain new access token.");
+        }
+
+    }
+
+    public ArrayList<String> getAccessToken(DynamicOptions dynamicOptions, String encodedRefreshAuth) {
+        HttpsClient httpsClient = new HttpsClient();
+        ArrayList<String> newAccessTokenArray;
+        if (!HttpConstants.EMPTY_STRING.equals(oauthUsername) &&
+                !HttpConstants.EMPTY_STRING.equals(oauthUserPassword)) {
+            newAccessTokenArray = httpsClient.getPasswordGrandAccessToken(publisherURL, clientStoreFile,
+                    clientStorePass, oauthUsername, oauthUserPassword, encodedRefreshAuth);
+        } else if (!HttpConstants.EMPTY_STRING.equals(refreshToken.getValue(dynamicOptions)) ||
+                !availableRefreshToken.equals(HttpConstants.EMPTY_STRING)) {
+            newAccessTokenArray = httpsClient.getRefreshGrandAccessToken(publisherURL, clientStoreFile,
+                    clientStorePass, encodedRefreshAuth, refreshToken.getValue(dynamicOptions));
+        } else {
+            newAccessTokenArray = httpsClient.getClientGrandAccessToken(publisherURL, clientStoreFile,
+                    clientStorePass, encodedRefreshAuth);
+        }
+        return newAccessTokenArray;
+    }
+
+    public void checkAccessToken(String encodedRefreshAuth, DynamicOptions dynamicOptions,
+                                 List<Header> headersList) {
+        //check the availability of the authorization
+        boolean authAvailability = false;
+        for (Header header : headersList) {
+            if (header.getName().equals(HttpConstants.AUTHORIZATION_HEADER)) {
+                authAvailability = true;
+            }
+        }
+        if (!authAvailability) {
+            //generate encoded base64 auth for getting refresh token
+            if (!accesstokenAvalable) {
+                ArrayList<String> accessTokenArray = getAccessToken(dynamicOptions, encodedRefreshAuth);
+                int responseCode = Integer.parseInt(accessTokenArray.get(0));
+
+                if (responseCode == HttpConstants.SUCCESS_CODE) {
+                    accessToken = "Bearer " + accessTokenArray.get(1);
+                    availableRefreshToken = accessTokenArray.get(2);
+                    accesstokenAvalable = true;
+                    accessTokenCache.setRefreshtoken(encodedRefreshAuth, availableRefreshToken);
+                    accessTokenCache.setAccessToken(encodedRefreshAuth, accessToken);
+                } else if (responseCode == HttpConstants.AUTHENTICATION_FAIL_CODE) {
+                    accessToken = HttpConstants.EMPTY_STRING;
+                    log.error(responseCode + ": Provide valid Consumer key, " +
+                            "Consumer secret for generate new access token.");
+                } else if (responseCode == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
+                    accessToken = HttpConstants.EMPTY_STRING;
+                    log.error(responseCode + ": Internal server Error.");
+                } else {
+                    log.error(responseCode + ": Can not obtain access token.");
+                }
+            }
+            headersList.add(new Header(HttpConstants.AUTHORIZATION_HEADER, accessToken));
+            headersList.add(new Header(HttpConstants.RECEIVER_REFRESH_TOKEN, availableRefreshToken));
+        } else {
+            //check the cache and update new access token into header
+            Boolean checkFromCache = accessTokenCache.checkAvailableKey(encodedRefreshAuth);
+            if (checkFromCache) {
+                accessToken = accessTokenCache.getAccessToken(encodedRefreshAuth);
+                for (Header header : headersList) {
+                    if (header.getName().equals(HttpConstants.AUTHORIZATION_HEADER)) {
+                        header.setValue(accessToken);
+                    }
+                }
+            }
+        }
+    }
+
+    private int sendRequest(Object payload, DynamicOptions dynamicOptions, List<Header> headersList) {
+        if (publisherURLOption.isStatic()) {
+            if (clientConnector != null) {
+                clientConnector.close();
+            }
+        }
+        initClientConnector(dynamicOptions);
         String httpMethod = EMPTY_STRING.equals(httpMethodOption.getValue(dynamicOptions)) ?
                 HttpConstants.METHOD_DEFAULT : httpMethodOption.getValue(dynamicOptions);
-        List<Header> headersList = HttpSinkUtil.getHeaders(headers);
         String contentType = HttpSinkUtil.getContentType(mapType, headersList);
         String messageBody = getMessageBody(payload);
         HttpMethod httpReqMethod = new HttpMethod(httpMethod);
@@ -579,42 +789,43 @@ public class HttpSink extends Sink {
                     .getBytes(Charset.defaultCharset()))));
         }
         cMessage.completeMessage();
-        clientConnector.send(cMessage);
+        CountDownLatch latch = new CountDownLatch(1);
+        DefaultListener listener = new DefaultListener(latch, authType);
+        HttpResponseFuture responseFuture = clientConnector.send(cMessage);
+        responseFuture.setHttpConnectorListener(listener);
+
+        if (HttpConstants.OAUTH.equals(authType)) {
+            try {
+                latch.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                log.debug("Time out due to getting new access token. " + e);
+                disconnect();
+            }
+        }
+        HTTPCarbonMessage response = listener.getHttpResponseMessage();
+        return response.getNettyHttpResponse().status().code();
     }
 
     /**
      * This method will be called before the processing method.
      * Intention to establish connection to publish event.
-     *
-     * @throws ConnectionUnavailableException if end point is unavailable the ConnectionUnavailableException thrown
-     *                                        such that the  system will take care retrying for connection
+     * such that the  system will take care retrying for connection
      */
     @Override
-    public void connect() throws ConnectionUnavailableException {
+    public void connect() {
         if (publisherURLOption.isStatic()) {
             log.info(streamID + " has successfully connected to " + publisherURL);
         }
     }
 
     /**
-     * Called after all publishing is done, or when {@link ConnectionUnavailableException} is thrown
-     * Implementation of this method should contain the steps needed to disconnect from the sink.
+     * Called after all publishing is done, the steps needed to disconnect from the sink.
      */
     @Override
     public void disconnect() {
         if (clientConnector != null) {
             clientConnector = null;
             log.info("Server connector for url " + publisherURL + " disconnected.");
-        }
-
-        if (httpConnectorFactory != null) {
-            try {
-                httpConnectorFactory.shutdown();
-                httpConnectorFactory = null;
-            } catch (InterruptedException e) {
-                log.info("Failed to shutdown the http connection factory while shutting down the siddhi app " +
-                        siddhiAppContext.getName());
-            }
         }
     }
 
@@ -722,21 +933,6 @@ public class HttpSink extends Sink {
         }
     }
 
-    void initConnectorFactory() {
-        //if bootstrap configurations are given then pass it if not let take default value of transport
-        if (!EMPTY_STRING.equals(bootstrapBoss) && !EMPTY_STRING.equals(bootstrapWorker)) {
-            if (!EMPTY_STRING.equals(bootstrapClient)) {
-                httpConnectorFactory = new DefaultHttpWsConnectorFactory(Integer.parseInt(bootstrapBoss),
-                        Integer.parseInt(bootstrapWorker), Integer.parseInt(bootstrapClient));
-            } else {
-                httpConnectorFactory = new DefaultHttpWsConnectorFactory(Integer.parseInt(bootstrapBoss),
-                        Integer.parseInt(bootstrapWorker), Integer.parseInt(bootstrapWorker));
-            }
-        } else {
-            httpConnectorFactory = new DefaultHttpWsConnectorFactory();
-        }
-    }
-
     void initClientConnector(DynamicOptions dynamicOptions) {
         if (publisherURLOption.isStatic()) {
             publisherURL = publisherURLOption.getValue();
@@ -772,6 +968,20 @@ public class HttpSink extends Sink {
             this.authorizationHeader = HttpConstants.AUTHORIZATION_METHOD + Base64.encode
                     (Unpooled.copiedBuffer(val));
         }
+        //if bootstrap configurations are given then pass it if not let take default value of transport
+        HttpWsConnectorFactory httpConnectorFactory;
+        if (!EMPTY_STRING.equals(bootstrapBoss) && !EMPTY_STRING.equals(bootstrapWorker)) {
+            if (!EMPTY_STRING.equals(bootstrapClient)) {
+                httpConnectorFactory = new DefaultHttpWsConnectorFactory(Integer.parseInt(bootstrapBoss),
+                        Integer.parseInt(bootstrapWorker), Integer.parseInt(bootstrapClient));
+            } else {
+                httpConnectorFactory = new DefaultHttpWsConnectorFactory(Integer.parseInt(bootstrapBoss),
+                        Integer.parseInt(bootstrapWorker), Integer.parseInt(bootstrapWorker));
+            }
+        } else {
+            httpConnectorFactory = new DefaultHttpWsConnectorFactory();
+        }
+
         //if proxy username and password not equal to null then create proxy configurations
         if (!EMPTY_STRING.equals(proxyHost) && !EMPTY_STRING.equals(proxyPort)) {
             try {
@@ -831,5 +1041,12 @@ public class HttpSink extends Sink {
             throw new SiddhiAppRuntimeException("Execution of Siddhi app " + siddhiAppContext.getName() +
                     " failed due to " + e.getMessage(), e);
         }
+    }
+
+    private String encodeBase64(String consumerKeyValue) {
+
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(consumerKeyValue.getBytes(StandardCharsets.UTF_8));
+        ByteBuf encodedByteBuf = Base64.encode(byteBuf);
+        return encodedByteBuf.toString(StandardCharsets.UTF_8);
     }
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -351,7 +351,43 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.SOCKET_IDEAL_
                         description = "Maximum wait for client connection pool.",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = "60000")
+                        defaultValue = "60000"),
+                @Parameter(
+                        name = "oauth.username",
+                        description = "The username to be included in the authentication header of the oauth" +
+                                "authentication enabled events. It is required to specify both username and" +
+                                "password to enable oauth authentication. If one of the parameter is not given" +
+                                "by user then an error is logged in the CLI ",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = " "),
+                @Parameter(
+                        name = "oauth.password",
+                        description = "The password to be included in the authentication header of the oauth" +
+                                "authentication enabled events. It is required to specify both username and" +
+                                "password to enable oauth authentication. If one of the parameter is not given" +
+                                "by user then an error is logged in the CLI ",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = " "),
+                @Parameter(
+                        name = "consumer.key",
+                        description = "consumer key for the Http request",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = " "),
+                @Parameter(
+                        name = "consumer.secret",
+                        description = "consumer secret for the Http request",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = " "),
+                @Parameter(
+                        name = "refresh.token",
+                        description = "refresh token for the Http request",
+                        type = {DataType.STRING},
+                        optional = true,
+                        defaultValue = " "),
         },
         examples = {
                 @Example(syntax =

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -1034,8 +1034,9 @@ public class HttpSink extends Sink {
         }
         if (authType.equals(HttpConstants.OAUTH)) {
             if (EMPTY_STRING.equals(consumerSecret) || EMPTY_STRING.equals(consumerKey)) {
-                throw new SiddhiAppCreationException(HttpConstants.CONSUMER_KEY + " and " + HttpConstants.CONSUMER_SECRET
-                        + " found empty but it is Mandatory field in " + HttpConstants.HTTP_SINK_ID + " in " + streamID);
+                throw new SiddhiAppCreationException(HttpConstants.CONSUMER_KEY + " and " +
+                        HttpConstants.CONSUMER_SECRET + " found empty but it is Mandatory field in " +
+                        HttpConstants.HTTP_SINK_ID + " in " + streamID);
             }
             if (EMPTY_STRING.equals(tokenURL)) {
                 throw new SiddhiAppCreationException(HttpConstants.TOKEN_URL + " found empty but it is Mandatory " +

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -478,7 +478,7 @@ public class HttpSink extends Sink {
     private String streamID;
     HttpClientConnector clientConnector;
     String mapType;
-    private static Map<String, String> httpURLProperties;
+    private Map<String, String> httpURLProperties;
     Option httpHeaderOption;
     Option httpMethodOption;
     private String consumerKey;
@@ -831,7 +831,10 @@ public class HttpSink extends Sink {
 
         if (HttpConstants.OAUTH.equals(authType)) {
             try {
-                latch.await(30, TimeUnit.SECONDS);
+                boolean latchCount = latch.await(30, TimeUnit.SECONDS);
+                if (!latchCount) {
+                    log.debug("Time out due to getting new access token. ");
+                }
             } catch (InterruptedException e) {
                 log.debug("Time out due to getting new access token. " + e);
             }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -604,7 +604,6 @@ public class HttpSink extends Sink {
         } else {
             sendOauthRequest(payload, dynamicOptions, headersList);
         }
-        disconnect();
     }
 
     private void sendOauthRequest(Object payload, DynamicOptions dynamicOptions, List<Header> headersList) {
@@ -799,7 +798,6 @@ public class HttpSink extends Sink {
                 latch.await(30, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 log.debug("Time out due to getting new access token. " + e);
-                disconnect();
             }
         }
         HTTPCarbonMessage response = listener.getHttpResponseMessage();

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -355,8 +355,8 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.SOCKET_IDEAL_
                 @Parameter(
                         name = "oauth.username",
                         description = "The username to be included in the authentication header of the oauth " +
-                                "authentication enabled events. It is required to specify both username and" +
-                                "password to enable oauth authentication. If one of the parameter is not given" +
+                                "authentication enabled events. It is required to specify both username and " +
+                                "password to enable oauth authentication. If one of the parameter is not given " +
                                 "by user then an error is logged in the CLI. It is only applicable for for Oauth" +
                                 " requests ",
                         type = {DataType.STRING},
@@ -365,8 +365,8 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.SOCKET_IDEAL_
                 @Parameter(
                         name = "oauth.password",
                         description = "The password to be included in the authentication header of the oauth " +
-                                "authentication enabled events. It is required to specify both username and" +
-                                "password to enable oauth authentication. If one of the parameter is not given" +
+                                "authentication enabled events. It is required to specify both username and " +
+                                "password to enable oauth authentication. If one of the parameter is not given " +
                                 "by user then an error is logged in the CLI. It is only applicable for for Oauth" +
                                 " requests ",
                         type = {DataType.STRING},
@@ -657,14 +657,14 @@ public class HttpSink extends Sink {
             log.info("Request sent successfully to " + publisherURL);
         } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
             log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                    response + "- Internal server error.");
+                    response + "- Internal server error. Message dropped");
             throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint, " +
-                    publisherURL + "', with response code: " + response + "- Internal server error.");
+                    publisherURL + "', with response code: " + response + "- Internal server error. Message dropped.");
         } else {
             log.error("Error at sending oauth request to API endpoint " +
-                    publisherURL + "', with response code: " + response);
+                    publisherURL + "', with response code: " + response + ". Message dropped.");
             throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint " +
-                    publisherURL + "', and response code: " + response);
+                    publisherURL + "', and response code: " + response + ". Message dropped.");
         }
     }
 
@@ -695,14 +695,14 @@ public class HttpSink extends Sink {
             requestForNewAccessToken(payload, dynamicOptions, headersList, encodedAuth);
         } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
             log.error("Error at sending oauth request to API endpoint, " + publisherURL + "', with response code: " +
-                    response + "- Internal server error.");
+                    response + "- Internal server error. Message dropped");
             throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint, " +
-                    publisherURL + "', with response code: " + response + "- Internal server error.");
+                    publisherURL + "', with response code: " + response + "- Internal server error. Message dropped");
         } else {
             log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                    response);
+                    response + ". Message dropped.");
             throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint " + publisherURL +
-                    "', with response code: " + response);
+                    "', with response code: " + response + ". Message dropped.");
         }
     }
 
@@ -737,33 +737,36 @@ public class HttpSink extends Sink {
             } else if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
                 log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
                         response + "- Authentication Failure. " +
-                        "Please provide a valid Consumer key and a Consumer secret.");
+                        "Please provide a valid Consumer key and a Consumer secret. Message dropped");
                 throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint " +
                         publisherURL + "', with response code: " + response + "- Authentication Failure. " +
-                        "Please provide a valid Consumer key and a Consumer secret.");
+                        "Please provide a valid Consumer key and a Consumer secret. Message dropped");
             } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
                 log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                        response + "- Internal server error.");
+                        response + "- Internal server error. Message dropped");
                 throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint "
-                        + publisherURL + "', with response code: " + response + "- Internal server error.");
+                        + publisherURL + "', with response code: " + response +
+                        "- Internal server error. Message dropped");
             } else {
                 log.error("Error at sending oauth request to API endpoint " + publisherURL + "', with response code: " +
-                        response);
+                        response + ". Message dropped.");
                 throw new HttpSinkAdaptorRuntimeException("Error at sending oauth request to API endpoint " +
-                        publisherURL + "', with response code: " + response);
+                        publisherURL + "', with response code: " + response + ". Message dropped.");
             }
         } else if (accessTokenCache.getResponseCode(encodedAuth) == HttpConstants.AUTHENTICATION_FAIL_CODE) {
             log.error("Failed to generate new access token for the expired access token to " + publisherURL + "', " +
                     accessTokenCache.getResponseCode(encodedAuth) + ": Authentication Failure. Please provide a valid" +
-                    " Consumer key and a Consumer secret.");
+                    " Consumer key and a Consumer secret. Message dropped");
             throw new HttpSinkAdaptorRuntimeException("Failed to generate new access token for the expired access " +
                     "token to " + publisherURL + "', " + accessTokenCache.getResponseCode(encodedAuth) +
-                    ": Authentication Failure. Please provide a valid Consumer key and a Consumer secret.");
+                    ": Authentication Failure. Please provide a valid Consumer key and a Consumer secret. " +
+                    "Message dropped");
         } else {
             log.error("Failed to generate new access token for the expired access token. Error code: " +
-                    accessTokenCache.getResponseCode(encodedAuth));
+                    accessTokenCache.getResponseCode(encodedAuth) + ". Message dropped.");
             throw new HttpSinkAdaptorRuntimeException("Failed to generate new access token for the expired" +
-                    " access token. Error code: " + accessTokenCache.getResponseCode(encodedAuth));
+                    " access token. Error code: " + accessTokenCache.getResponseCode(encodedAuth)
+                    + ". Message dropped.");
         }
     }
 
@@ -806,23 +809,25 @@ public class HttpSink extends Sink {
                 } else if (accessTokenCache.getResponseCode(encodedAuth) == HttpConstants.AUTHENTICATION_FAIL_CODE) {
                     log.error("Failed to generate new access token for the expired access token to " + publisherURL +
                             "', with response code: " + accessTokenCache.getResponseCode(encodedAuth) +
-                            "- Authentication Failure. Please provide a valid Consumer key and a Consumer secret.");
+                            "- Authentication Failure. Please provide a valid Consumer key and a Consumer secret." +
+                            " Message dropped");
                     throw new HttpSinkAdaptorRuntimeException("Failed to generate new access token for the expired" +
                             " access token to " + publisherURL + "', with response code: " +
                             accessTokenCache.getResponseCode(encodedAuth) + "- Authentication Failure. " +
-                            "Please provide a valid Consumer key and a Consumer secret.");
+                            "Please provide a valid Consumer key and a Consumer secret. Message dropped");
                 } else if (accessTokenCache.getResponseCode(encodedAuth) == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
                     log.error("Failed to generate new access token for the expired access token to " + publisherURL +
                             "', with response code: " + accessTokenCache.getResponseCode(encodedAuth) +
-                            "- Internal server error.");
+                            "- Internal server error. Message dropped");
                     throw new HttpSinkAdaptorRuntimeException("Failed to generate new access token for the expired" +
                             " access token to " + publisherURL + "', with response code: " +
-                            accessTokenCache.getResponseCode(encodedAuth) + "- Internal server error.");
+                            accessTokenCache.getResponseCode(encodedAuth) + "- Internal server error. Message dropped");
                 } else {
                     log.error("Failed to generate new access token for the expired access token. Error code: " +
-                            accessTokenCache.getResponseCode(encodedAuth));
+                            accessTokenCache.getResponseCode(encodedAuth) + ". Message dropped.");
                     throw new HttpSinkAdaptorRuntimeException("Failed to generate new access token for the expired" +
-                            " access token. Error code: " + accessTokenCache.getResponseCode(encodedAuth));
+                            " access token. Error code: " + accessTokenCache.getResponseCode(encodedAuth) +
+                            ". Message dropped.");
                 }
         } else {
             //check the cache and update new access token into header
@@ -867,15 +872,15 @@ public class HttpSink extends Sink {
             try {
                 boolean latchCount = latch.await(30, TimeUnit.SECONDS);
                 if (!latchCount) {
-                    log.debug("Time out due to getting getting response from " + publisherURL);
+                    log.debug("Time out due to getting getting response from " + publisherURL + ". Message dropped.");
                     throw new HttpSinkAdaptorRuntimeException("Time out due to getting getting response from "
-                            + publisherURL);
+                            + publisherURL + ". Message dropped.");
 
                 }
             } catch (InterruptedException e) {
-                log.debug("Failed to get a response from " + publisherURL + "," + e);
+                log.debug("Failed to get a response from " + publisherURL + "," + e + ". Message dropped.");
                 throw new HttpSinkAdaptorRuntimeException("Failed to get a response from " +
-                        publisherURL + ", " + e);
+                        publisherURL + ", " + e + ". Message dropped.");
             }
         }
         HTTPCarbonMessage response = listener.getHttpResponseMessage();

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/exception/HttpSinkAdaptorRuntimeException.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/exception/HttpSinkAdaptorRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/AccessTokenCache.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/AccessTokenCache.java
@@ -24,18 +24,25 @@ import java.util.Map;
  * {@code AccessTokenCache} Handle the access token caching.
  */
 public class AccessTokenCache {
-    private Map<String , String> accessToken;
-    private Map<String , String> refreshToken;
+    private static Map<String , String> accessToken;
+    private static Map<String , String> refreshToken;
+    private static Map<String , Integer> responseCode;
 
-    private static AccessTokenCache sc = new AccessTokenCache();
+    private static AccessTokenCache accessTokenCache;
 
-    public static AccessTokenCache getInstance() {
-        return sc;
+    private AccessTokenCache() {
     }
 
-    public AccessTokenCache() {
-        accessToken = new HashMap<String, String>();
-        refreshToken = new HashMap<String, String>();
+    public static synchronized AccessTokenCache getInstance() {
+        if (accessTokenCache == null) {
+            accessTokenCache = new AccessTokenCache();
+            accessToken = new HashMap<>();
+            refreshToken = new HashMap<>();
+            responseCode = new HashMap<>();
+            return accessTokenCache;
+        } else {
+            return accessTokenCache;
+        }
     }
 
     public void setAccessToken(String key, String value) {
@@ -44,6 +51,14 @@ public class AccessTokenCache {
 
     public void setRefreshtoken(String key, String value) {
         refreshToken.put(key, value);
+    }
+
+    public void setResponseCode(String key, int value) {
+        responseCode.put(key, value);
+    }
+
+    public int getResponseCode(String key) {
+        return responseCode.get(key);
     }
 
     public String getAccessToken(String key) {
@@ -59,6 +74,6 @@ public class AccessTokenCache {
     }
 
     public boolean checkRefreshAvailableKey(String value) {
-        return refreshToken.containsKey(value);
+            return refreshToken.containsKey(value);
     }
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/AccessTokenCache.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/AccessTokenCache.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.extension.siddhi.io.http.sink.updatetoken;
+
+import java.util.HashMap;
+import java.util.Map;
+/**
+ * {@code AccessTokenCache} Handle the access token caching.
+ */
+public class AccessTokenCache {
+    private Map<String , String> accessToken;
+    private Map<String , String> refreshToken;
+
+    private static AccessTokenCache sc = new AccessTokenCache();
+
+    public static AccessTokenCache getInstance() {
+        return sc;
+    }
+
+    public AccessTokenCache() {
+        accessToken = new HashMap<String, String>();
+        refreshToken = new HashMap<String, String>();
+    }
+
+    public void setAccessToken(String key, String value) {
+        accessToken.put(key, value);
+    }
+
+    public void setRefreshtoken(String key, String value) {
+        refreshToken.put(key, value);
+    }
+
+    public String getAccessToken(String key) {
+        return accessToken.get(key);
+    }
+
+    public String getRefreshtoken(String key) {
+        return refreshToken.get(key);
+    }
+
+    public boolean checkAvailableKey(String value) {
+        return accessToken.containsKey(value);
+    }
+
+    public boolean checkRefreshAvailableKey(String value) {
+        return refreshToken.containsKey(value);
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/DefaultListener.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/DefaultListener.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/DefaultListener.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/DefaultListener.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.extension.siddhi.io.http.sink.updatetoken;
+
+import org.wso2.extension.siddhi.io.http.util.HttpConstants;
+import org.wso2.transport.http.netty.contract.HttpConnectorListener;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.Http2PushPromise;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * {@code DefaultListner} Handle the HTTP listner.
+ */
+public class DefaultListener implements HttpConnectorListener {
+    private HTTPCarbonMessage httpMessage;
+    private CountDownLatch latch;
+    private String authType;
+
+
+    public DefaultListener(CountDownLatch latch, String authType) {
+        this.latch = latch;
+        this.authType = authType;
+    }
+
+    @Override
+    public void onMessage(HTTPCarbonMessage httpMessage) {
+        this.httpMessage = httpMessage;
+        if (HttpConstants.OAUTH.equals(authType)) {
+            latch.countDown();
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        latch.countDown();
+    }
+
+    @Override
+    public void onPushPromise(Http2PushPromise pushPromise) {
+
+    }
+
+    public HTTPCarbonMessage getHttpResponseMessage() {
+        return httpMessage;
+    }
+
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpRequest.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpRequest.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpRequest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.extension.siddhi.io.http.sink.updatetoken;
+
+import io.netty.buffer.Unpooled;
+
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.extension.siddhi.io.http.util.HttpConstants;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpResponseFuture;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * {@code HttpRequest} Handle the HTTP request for invalid access token.
+ */
+public class HttpRequest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpRequest.class);
+
+    public static ArrayList<String> sendPostRequest(HttpClientConnector httpClientConnector, String serverScheme,
+                                                    String serverHost, int serverPort, String serverPath,
+                                                    String payload, Map<String, String> headers) {
+        ArrayList<String> responses = new ArrayList<>();
+
+        HTTPCarbonMessage msg = createHttpPostReq(serverScheme, serverHost, serverPort, serverPath, payload);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            msg.setHeader(entry.getKey(), entry.getValue());
+        }
+        CountDownLatch latch = new CountDownLatch(1);
+        DefaultListener listener = new DefaultListener(latch, HttpConstants.OAUTH);
+        HttpResponseFuture responseFuture = httpClientConnector.send(msg);
+        responseFuture.setHttpConnectorListener(listener);
+        try {
+            latch.await(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOG.debug("Time out due to getting new access token. " + e);
+        }
+        HTTPCarbonMessage response = listener.getHttpResponseMessage();
+        String statusCode = Integer.toString(response.getNettyHttpResponse().status().code());
+        responses.add(statusCode);
+        String responsePayload = new BufferedReader(
+                new InputStreamReader(new HttpMessageDataStreamer(response).getInputStream())).lines()
+                .collect(Collectors.joining("\n"));
+        responses.add(responsePayload);
+        return responses;
+    }
+
+    private static HTTPCarbonMessage createHttpPostReq(String serverScheme, String serverHost, int serverPort,
+                                                       String serverPath, String payload) {
+        HTTPCarbonMessage httpPostRequest = new HTTPCarbonMessage(
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, serverPath));
+        httpPostRequest.setProperty(Constants.PROTOCOL, serverScheme);
+        httpPostRequest.setProperty(Constants.HTTP_HOST, serverHost);
+        httpPostRequest.setProperty(Constants.HTTP_PORT, serverPort);
+        httpPostRequest.setProperty(Constants.TO, serverPath);
+        httpPostRequest.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(payload.getBytes(Charset.forName("UTF-8")));
+        httpPostRequest.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+        return httpPostRequest;
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpRequest.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpRequest.java
@@ -82,7 +82,7 @@ public class HttpRequest {
             String responsePayload = buffer.lines().collect(Collectors.joining("\n"));
             responses.add(responsePayload);
         } catch (IOException e) {
-            LOG.debug("There was an error in reading the file" + e);
+            LOG.debug("There was an error in reading the file while generating new access token. " + e);
         }
         return responses;
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpsClient.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpsClient.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpsClient.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/updatetoken/HttpsClient.java
@@ -1,0 +1,189 @@
+/*
+ *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.extension.siddhi.io.http.sink.updatetoken;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.extension.siddhi.io.http.util.HttpConstants;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wso2.transport.http.netty.common.Constants.HTTPS_SCHEME;
+
+
+/**
+ * {@code HttpsClient} Handle the HTTP client.
+ */
+public class HttpsClient {
+    private static final Logger LOG = LoggerFactory.getLogger(HttpsClient.class);
+
+    public ArrayList<String> getPasswordGrandAccessToken(String url, String trustStorePath, String trustStorePassword,
+                                                      String username, String password, String encodedAuth) {
+        ArrayList<String> serverInfo = getServerInfo(url);
+        HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
+        HttpClientConnector httpClientConnector = factory
+                .createHttpClientConnector(new HashMap<>(), getSenderConfigurationForHttp(trustStorePath,
+                        trustStorePassword));
+        final Map<String, String> refreshTokenBody = new HashMap<>();
+        refreshTokenBody.put(HttpConstants.GRANT_TYPE, HttpConstants.GRANT_PASSWORD);
+        refreshTokenBody.put(HttpConstants.USERNAME, username);
+        refreshTokenBody.put(HttpConstants.PASSWORD, password);
+        String payload = getPayload(refreshTokenBody);
+        Map<String, String> headers = setHeaders(encodedAuth);
+        ArrayList<String> tokenResponse = new ArrayList<>();
+        ArrayList<String> response = HttpRequest.sendPostRequest(httpClientConnector, Constants.HTTPS_SCHEME,
+                serverInfo.get(1), Integer.parseInt(serverInfo.get(0)), HttpConstants.SUFFIX_REFRESH_TOKEN_URL, payload,
+                headers);
+        String[] responseArray = response.get(1).split(HttpConstants.COMMA_SEPARATOR);
+        int statusCode = Integer.parseInt(response.get(0));
+        if (statusCode == HttpConstants.SUCCESS_CODE) {
+            String accessToken = responseArray[0].replace(HttpConstants.ACCESS_TOKEN_SPLIT, HttpConstants.EMPTY_STRING)
+                    .replace(HttpConstants.INVERTED_COMMA_SEPARATOR, HttpConstants.EMPTY_STRING);
+            String refreshToken = responseArray[1].replace(HttpConstants.REFRESH_TOKEN_SPLIT,
+                    HttpConstants.EMPTY_STRING).replace(HttpConstants.INVERTED_COMMA_SEPARATOR,
+                    HttpConstants.EMPTY_STRING);
+            tokenResponse.add(response.get(0));
+            tokenResponse.add(accessToken);
+            tokenResponse.add(refreshToken);
+        } else {
+            tokenResponse.add(response.get(0));
+        }
+        return tokenResponse;
+
+    }
+
+    public ArrayList<String> getRefreshGrandAccessToken(String url, String trustStorePath, String trustStorePassword,
+                                                     String encodedAuth, String refreshToken) {
+        ArrayList<String> serverInfo = getServerInfo(url);
+        HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
+        HttpClientConnector httpClientConnector = factory
+                .createHttpClientConnector(new HashMap<>(), getSenderConfigurationForHttp(trustStorePath,
+                        trustStorePassword));
+        ArrayList<String> tokenResponse = new ArrayList<>();
+        final Map<String, String> refreshTokenBody = new HashMap<>();
+        Map<String, String> headers = setHeaders(encodedAuth);
+        refreshTokenBody.put(HttpConstants.GRANT_TYPE, HttpConstants.GRANT_REFRESHTOKEN);
+        refreshTokenBody.put(HttpConstants.GRANT_REFRESHTOKEN, refreshToken);
+        String payload = getPayload(refreshTokenBody);
+        ArrayList<String> response = HttpRequest.sendPostRequest(httpClientConnector, Constants.HTTP_SCHEME,
+                serverInfo.get(1), Integer.parseInt(serverInfo.get(0)), HttpConstants.SUFFIX_NEW_ACCESS_TOKEN_URL,
+                payload, headers);
+        String[] responseArray = response.get(1).split(HttpConstants.COMMA_SEPARATOR);
+        int statusCode = Integer.parseInt(response.get(0));
+        if (statusCode == HttpConstants.SUCCESS_CODE) {
+            String token = responseArray[0].replace(HttpConstants.ACCESS_TOKEN_SPLIT, HttpConstants.EMPTY_STRING)
+                    .replace(HttpConstants.INVERTED_COMMA_SEPARATOR, HttpConstants.EMPTY_STRING);
+            String newRefreshToken = responseArray[1].replace(HttpConstants.REFRESH_TOKEN_SPLIT,
+                    HttpConstants.EMPTY_STRING).replace(HttpConstants.INVERTED_COMMA_SEPARATOR,
+                    HttpConstants.EMPTY_STRING);
+            tokenResponse.add(response.get(0));
+            tokenResponse.add(token);
+            tokenResponse.add(newRefreshToken);
+            return tokenResponse;
+        } else if (statusCode == HttpConstants.AUTHENTICATION_FAIL_CODE
+                || statusCode == HttpConstants.PERSISTENT_ACCESS_FAIL_CODE) {
+            return getClientGrandAccessToken(url, trustStorePath, trustStorePassword, encodedAuth);
+        } else {
+            tokenResponse.add(response.get(0));
+            return tokenResponse;
+        }
+    }
+
+    public ArrayList<String> getClientGrandAccessToken(String url, String trustStorePath, String trustStorePassword,
+                                                    String encodedAuth) {
+        String token;
+        ArrayList<String> serverInfo = getServerInfo(url);
+        HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
+        HttpClientConnector httpClientConnector = factory
+                .createHttpClientConnector(new HashMap<>(), getSenderConfigurationForHttp(trustStorePath,
+                        trustStorePassword));
+        ArrayList<String> tokenResponse = new ArrayList<>();
+        final Map<String, String> refreshTokenBody = new HashMap<>();
+        refreshTokenBody.put(HttpConstants.GRANT_TYPE, HttpConstants.GRANT_CLIENTTOKEN);
+        String payload = getPayload(refreshTokenBody);
+        Map<String, String> headers = setHeaders(encodedAuth);
+        ArrayList<String> response = HttpRequest.sendPostRequest(httpClientConnector, Constants.HTTP_SCHEME,
+                serverInfo.get(1), Integer.parseInt(serverInfo.get(0)), HttpConstants.SUFFIX_NEW_ACCESS_TOKEN_URL,
+                payload, headers);
+        String[] responseArray = response.get(1).split(HttpConstants.COMMA_SEPARATOR);
+        int statusCode = Integer.parseInt(response.get(0));
+        if (statusCode == HttpConstants.SUCCESS_CODE) {
+            token = responseArray[0].replace(HttpConstants.ACCESS_TOKEN_SPLIT, HttpConstants.EMPTY_STRING)
+                    .replace(HttpConstants.INVERTED_COMMA_SEPARATOR, HttpConstants.EMPTY_STRING);
+            tokenResponse.add(response.get(0));
+            tokenResponse.add(token);
+            tokenResponse.add(HttpConstants.EMPTY_STRING);
+        } else {
+            tokenResponse.add(response.get(0));
+        }
+        return tokenResponse;
+    }
+
+    private static SenderConfiguration getSenderConfigurationForHttp(String trustStorePath, String trustStorePassword) {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setTrustStoreFile(trustStorePath);
+        senderConfiguration.setTrustStorePass(trustStorePassword);
+        senderConfiguration.setScheme(HTTPS_SCHEME);
+        senderConfiguration.setHostNameVerificationEnabled(false);
+        return senderConfiguration;
+    }
+
+    private static String encodeMessage(Object s) {
+        try {
+            return URLEncoder.encode((String) s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            LOG.error("Unable to encode the message: " + e);
+            return "Unable to encode the message: " + e;
+        }
+    }
+
+    private static String getPayload(Map<String, String> refreshTokenBody) {
+        return refreshTokenBody.entrySet().stream()
+                .map(p -> encodeMessage(p.getKey()) + "=" + encodeMessage(p.getValue()))
+                .reduce("", (p1, p2) -> p1 + "&" + p2);
+    }
+
+    private static ArrayList<String> getServerInfo(String url) {
+        ArrayList<String> serverInfo = new ArrayList<>();
+        String splitUrl[] = url.split(HttpConstants.PROTOCOL_HOST_SEPARATOR);
+        String splitByColon[] = splitUrl[1].split(HttpConstants.PORT_HOST_SEPARATOR);
+        String serverPorts[] = splitByColon[1].split(HttpConstants.PORT_CONTEXT_SEPARATOR);
+        serverInfo.add(Integer.valueOf(serverPorts[0]).toString());
+        serverInfo.add(splitByColon[0]);
+        return serverInfo;
+    }
+
+    private static HashMap<String, String> setHeaders(String encodedAuth) {
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(HttpConstants.AUTHORIZATION_HEADER, encodedAuth);
+        headers.put(HttpConstants.HTTP_CONTENT_TYPE,
+                String.valueOf(HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED));
+        return headers;
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/util/HttpSinkUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/util/HttpSinkUtil.java
@@ -78,8 +78,10 @@ public class HttpSinkUtil {
             httpStaticProperties = new HashMap<>();
             httpStaticProperties.put(Constants.TO, url.getFile());
             String protocol = url.getProtocol();
+            String path = url.getPath();
             httpStaticProperties.put(Constants.PROTOCOL, protocol);
             httpStaticProperties.put(Constants.HTTP_HOST, url.getHost());
+            httpStaticProperties.put(HttpConstants.PATH, path);
             int port;
             if (Constants.HTTPS_SCHEME.equalsIgnoreCase(protocol)) {
                 port = url.getPort() != -1 ? url.getPort() : HttpConstants.DEFAULT_HTTPS_PORT;

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -91,6 +91,9 @@ public class HttpConstants {
     public static final String CREDENTIAL_SEPARATOR = ":";
     public static final String PORT_CONTEXT_SEPARATOR = "/";
     public static final String PORT_CONTEXT_KEY_SEPARATOR = "-";
+    public static final String COMMA_SEPARATOR = ",";
+    public static final String INVERTED_COMMA_SEPARATOR = "\"";
+
 
     //GlobaleConfigurations
     public static final String HTTP_PORT = "defaultHttpPort";
@@ -215,4 +218,37 @@ public class HttpConstants {
     // HTTP Default ports if the port is not present in the given URL
     public static final int DEFAULT_HTTP_PORT = 80;
     public static final int DEFAULT_HTTPS_PORT = 443;
+
+    //getting refreshtoken and new access token
+    public static final String CONSUMER_SECRET = "consumer.secret";
+    public static final String CONSUMER_KEY = "consumer.key";
+    public static final String SUFFIX_REFRESH_TOKEN_URL = "/token";
+    public static final String GRANT_TYPE = "grant_type";
+    public static final String GRANT_PASSWORD = "password";
+    public static final String GRANT_REFRESHTOKEN = "refresh_token";
+    public static final String GRANT_ACCESSTOKEN = "access_token";
+    public static final String GRANT_CLIENTTOKEN = "client_credentials";
+    public static final String USERNAME = "username";
+    public static final String PASSWORD = "password";
+    public static final String SUFFIX_NEW_ACCESS_TOKEN_URL = "/token";
+    public static final String TOKEN = "token";
+    public static final String TOKEN_TYPE_HINT = "token_type_hint";
+    public static final String SUFFIX_REVOKE_URL = "/revoke";
+    public static final int SUCCESS_CODE = 200;
+    public static final int AUTHENTICATION_FAIL_CODE = 401;
+    public static final int PERSISTENT_ACCESS_FAIL_CODE = 400;
+    public static final int INTERNAL_SERVER_FAIL_CODE = 500;
+    public static final String RECEIVER_OAUTH_USERNAME = "oauth.username";
+    public static final String RECEIVER_OAUTH_PASSWORD = "oauth.password";
+    public static final String RECEIVER_REFRESH_TOKEN = "refresh.token";
+    public static final String ACCESS_TOKEN_SPLIT = "{\"access_token\":\"";
+    public static final String REFRESH_TOKEN_SPLIT = "\"refresh_token\":\"";
+    public static final String BASIC_AUTH = "basic.auth";
+    public static final String NO_AUTH = "no.auth";
+    public static final String OAUTH = "oauth";
+    public static final int MAXIMUM_TRY_COUNT = 2;
+    public static final int MINIMUM_TRY_COUNT = 1;
+
+
+
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -91,9 +91,6 @@ public class HttpConstants {
     public static final String CREDENTIAL_SEPARATOR = ":";
     public static final String PORT_CONTEXT_SEPARATOR = "/";
     public static final String PORT_CONTEXT_KEY_SEPARATOR = "-";
-    public static final String COMMA_SEPARATOR = ",";
-    public static final String INVERTED_COMMA_SEPARATOR = "\"";
-
     //GlobaleConfigurations
     public static final String HTTP_PORT = "defaultHttpPort";
     public static final String HTTP_PORT_VALUE = "8280";
@@ -219,20 +216,16 @@ public class HttpConstants {
     public static final int DEFAULT_HTTPS_PORT = 443;
 
     //getting refreshtoken and new access token
+    public static final String PATH = "path";
+    public static final String TOKEN_URL = "token.url";
     public static final String CONSUMER_SECRET = "consumer.secret";
     public static final String CONSUMER_KEY = "consumer.key";
-    public static final String SUFFIX_REFRESH_TOKEN_URL = "/token";
     public static final String GRANT_TYPE = "grant_type";
     public static final String GRANT_PASSWORD = "password";
     public static final String GRANT_REFRESHTOKEN = "refresh_token";
-    public static final String GRANT_ACCESSTOKEN = "access_token";
     public static final String GRANT_CLIENTTOKEN = "client_credentials";
     public static final String USERNAME = "username";
     public static final String PASSWORD = "password";
-    public static final String SUFFIX_NEW_ACCESS_TOKEN_URL = "/token";
-    public static final String TOKEN = "token";
-    public static final String TOKEN_TYPE_HINT = "token_type_hint";
-    public static final String SUFFIX_REVOKE_URL = "/revoke";
     public static final int SUCCESS_CODE = 200;
     public static final int AUTHENTICATION_FAIL_CODE = 401;
     public static final int PERSISTENT_ACCESS_FAIL_CODE = 400;
@@ -240,11 +233,10 @@ public class HttpConstants {
     public static final String RECEIVER_OAUTH_USERNAME = "oauth.username";
     public static final String RECEIVER_OAUTH_PASSWORD = "oauth.password";
     public static final String RECEIVER_REFRESH_TOKEN = "refresh.token";
-    public static final String ACCESS_TOKEN_SPLIT = "{\"access_token\":\"";
-    public static final String REFRESH_TOKEN_SPLIT = "\"refresh_token\":\"";
     public static final String BASIC_AUTH = "basic.auth";
     public static final String NO_AUTH = "no.auth";
     public static final String OAUTH = "oauth";
     public static final int MAXIMUM_TRY_COUNT = 2;
     public static final int MINIMUM_TRY_COUNT = 1;
+    public static final String NEW_LINE = "\n";
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -94,7 +94,6 @@ public class HttpConstants {
     public static final String COMMA_SEPARATOR = ",";
     public static final String INVERTED_COMMA_SEPARATOR = "\"";
 
-
     //GlobaleConfigurations
     public static final String HTTP_PORT = "defaultHttpPort";
     public static final String HTTP_PORT_VALUE = "8280";
@@ -248,7 +247,4 @@ public class HttpConstants {
     public static final String OAUTH = "oauth";
     public static final int MAXIMUM_TRY_COUNT = 2;
     public static final int MINIMUM_TRY_COUNT = 1;
-
-
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,11 @@
                 <version>${org.wso2.carbon.transport.http.netty.version}</version>
                 <type>zip</type>
             </dependency>
+            <dependency>
+                <groupId>org.json.wso2</groupId>
+                <artifactId>json</artifactId>
+                <version>${org.json.wso2.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <properties>
@@ -388,6 +393,7 @@
         <carbon.datasources.version>1.1.3</carbon.datasources.version>
         <org.wso2.carbon.transport.http.netty.version>5.0.1</org.wso2.carbon.transport.http.netty.version>
         <msf4j.version>2.6.2</msf4j.version>
+        <org.json.wso2.version>3.0.0.wso2v1</org.json.wso2.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <siddhi.mapper.json.version>4.0.31</siddhi.mapper.json.version>
         <siddhi.mapper.text.version>1.0.22</siddhi.mapper.text.version>


### PR DESCRIPTION
## Purpose
> In the Siddhi application, we can make a connection with the API Manager. Sometimes when we connect with APIM we get "Authentication failure" as a response because of the access token expired.
## Goals
> User can send an HTTP request without worrying about the access token expiration. The system automatically generates a new access token for the user.
## Approach
>  In the beginning, the system categorizes the Authentication type (no-auth/basic auth/OAuth) based on the parameter pass by the user. If Authentication type is no-auth/basic auth then it goes on a normal flow. Authentication type is OAuth and the authentication fails then it again checks the parameters. Based on the parameters it will re-generate the new access token using a grant type(refresh-token/ password credential/ Client credential). In addition, if the user didn't give the access token then the system automatically get the access token and also if two or more siddhi sink uses the same invalid access token at the same time then the system automatically get the new access token once and validate all requests.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
