### PR TITLE
Introduce blocking io functionality to http-request sink

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -546,6 +546,7 @@ public class HttpRequestSink extends HttpSink {
         if (isBlockingIO) {
             responseLatch = new CountDownLatch(1);
         }
+        return stateFactory;
     }
 
     /**

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -410,6 +410,14 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = " "),
+                @Parameter(
+                        name = "wait.for.response",
+                        description = "If this is set to 'true', after sending a request, http-request sink waits " +
+                                "until the it receives the response for that request, " +
+                                "before sending any other request.",
+                        type = {DataType.BOOL},
+                        optional = true,
+                        defaultValue = "false"),
         },
         examples = {
                 @Example(syntax =
@@ -500,6 +508,8 @@ public class HttpRequestSink extends HttpSink {
     private AccessTokenCache accessTokenCache = AccessTokenCache.getInstance();
     private String publisherURL;
     private String tokenURL;
+    private boolean waitForResponse;
+    private CountDownLatch responseLatch;
 
     @Override
     protected StateFactory init(StreamDefinition outputStreamDefinition, OptionHolder optionHolder,
@@ -532,7 +542,11 @@ public class HttpRequestSink extends HttpSink {
         } else {
             authType = HttpConstants.NO_AUTH;
         }
-        return stateFactory;
+        waitForResponse = Boolean.parseBoolean(
+                optionHolder.validateAndGetStaticValue(HttpConstants.WAIT_FOR_RESPONSE, HttpConstants.FALSE));
+        if (waitForResponse) {
+            responseLatch = new CountDownLatch(1);
+        }
     }
 
     /**
@@ -712,12 +726,13 @@ public class HttpRequestSink extends HttpSink {
         }
         cMessage.completeMessage();
         HttpResponseFuture httpResponseFuture = clientConnector.send(cMessage);
-        CountDownLatch latch = new CountDownLatch(1);
-        HttpResponseMessageListener httpListener =
-                new HttpResponseMessageListener(getTrpProperties(dynamicOptions), sinkId, isDownloadEnabled, latch,
-                        tryCount, authType);
+        HttpResponseMessageListener httpListener;
+        CountDownLatch latch = waitForResponse ? responseLatch : new CountDownLatch(1);
+        httpListener = new HttpResponseMessageListener(getTrpProperties(dynamicOptions), sinkId,
+                isDownloadEnabled, latch, tryCount, authType, waitForResponse);
         httpResponseFuture.setHttpConnectorListener(httpListener);
-        if (HttpConstants.OAUTH.equals(authType)) {
+
+        if (waitForResponse || HttpConstants.OAUTH.equals(authType)) {
             try {
                 boolean latchCount = latch.await(30, TimeUnit.SECONDS);
                 if (!latchCount) {
@@ -730,6 +745,10 @@ public class HttpRequestSink extends HttpSink {
                 log.debug("Failed to get a response from " + publisherURL + "," + e + ". Message dropped.");
                 throw new HttpSinkAdaptorRuntimeException("Failed to get a response from " +
                         publisherURL + ", " + e + ". Message dropped.");
+            }
+            if (waitForResponse) {
+                responseLatch = new CountDownLatch(1);
+                return HttpConstants.SUCCESS_CODE;
             }
             HttpCarbonMessage response = httpListener.getHttpResponseMessage();
             return response.getNettyHttpResponse().status().code();

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -413,8 +413,7 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
                 @Parameter(
                         name = "wait.for.response",
                         description = "If this is set to 'true', after sending a request, http-request sink waits " +
-                                "until the it receives the response for that request, " +
-                                "before sending any other request.",
+                                "until it receives the response for that request, before sending any other request.",
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "false"),

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/source/HttpResponseMessageListener.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/source/HttpResponseMessageListener.java
@@ -46,17 +46,17 @@ public class HttpResponseMessageListener implements HttpConnectorListener {
     private CountDownLatch latch;
     private int tryCount;
     private String authType;
-    private boolean waitForResponse;
+    private boolean isBlockingIO;
 
     public HttpResponseMessageListener(Map<String, Object> trpProperties, String sinkId, boolean isDownloadEnabled,
-                                       CountDownLatch latch, int tryCount, String authType, boolean waitForResponse) {
+                                       CountDownLatch latch, int tryCount, String authType, boolean isBlockingIO) {
         this.trpProperties = trpProperties;
         this.isDownloadEnabled = isDownloadEnabled;
         this.sinkId = sinkId;
         this.latch = latch;
         this.tryCount = tryCount;
         this.authType = authType;
-        this.waitForResponse = waitForResponse;
+        this.isBlockingIO = isBlockingIO;
     }
 
     @Override
@@ -78,7 +78,7 @@ public class HttpResponseMessageListener implements HttpConnectorListener {
                         "' has been defined. Hence dropping the response message.");
             }
         }
-        if (waitForResponse || HttpConstants.OAUTH.equals(authType)) {
+        if (isBlockingIO || HttpConstants.OAUTH.equals(authType)) {
             latch.countDown();
         }
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/source/HttpResponseMessageListener.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/source/HttpResponseMessageListener.java
@@ -46,15 +46,17 @@ public class HttpResponseMessageListener implements HttpConnectorListener {
     private CountDownLatch latch;
     private int tryCount;
     private String authType;
+    private boolean waitForResponse;
 
     public HttpResponseMessageListener(Map<String, Object> trpProperties, String sinkId, boolean isDownloadEnabled,
-                                       CountDownLatch latch, int tryCount, String authType) {
+                                       CountDownLatch latch, int tryCount, String authType, boolean waitForResponse) {
         this.trpProperties = trpProperties;
         this.isDownloadEnabled = isDownloadEnabled;
         this.sinkId = sinkId;
         this.latch = latch;
         this.tryCount = tryCount;
         this.authType = authType;
+        this.waitForResponse = waitForResponse;
     }
 
     @Override
@@ -76,7 +78,7 @@ public class HttpResponseMessageListener implements HttpConnectorListener {
                         "' has been defined. Hence dropping the response message.");
             }
         }
-        if (HttpConstants.OAUTH.equals(authType)) {
+        if (waitForResponse || HttpConstants.OAUTH.equals(authType)) {
             latch.countDown();
         }
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -223,5 +223,5 @@ public class HttpConstants {
     public static final String BEARER = "Bearer ";
     public static final String ACCESS_TOKEN = "access_token";
     public static final String REFRESH_TOKEN = "refresh_token";
-    public static final String WAIT_FOR_RESPONSE = "wait.for.response";
+    public static final String BLOCKING_IO = "blocking.io";
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -223,6 +223,5 @@ public class HttpConstants {
     public static final String BEARER = "Bearer ";
     public static final String ACCESS_TOKEN = "access_token";
     public static final String REFRESH_TOKEN = "refresh_token";
-    private HttpConstants() {
-    }
+    public static final String WAIT_FOR_RESPONSE = "wait.for.response";
 }


### PR DESCRIPTION
## Purpose
This allows users to configure the http-request sink in a way that before sending more requests, request-sink waits after sending a request until it receives a response for that request.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes